### PR TITLE
loading screen implementation

### DIFF
--- a/components/Loading/PageLoader.tsx
+++ b/components/Loading/PageLoader.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import ProgressLoader from './ProgressLoader'
+
+const PageLoader = () => {
+  return (
+    <div className='flex h-screen w-full items-center justify-center flex-col text-center'>
+      <h1 className='lg:text-[100px] font-black uppercase leading-none'>Wrapping <span className='text-[50px] leading-none bg-linear-to-r from-[#cfcfd0] to-[#B0ADBF] font-black block mt-4 bg-clip-text px-3 text-transparent'>your year</span></h1>
+  <div
+  className="
+    relative my-8 rounded-lg px-8 text-center
+    border border-[#b408b4]
+    shadow-[0_2px_5px_rgba(180,8,180,0.9)]
+  "
+>
+  <p className="
+    uppercase text-[60px] font-black inline-flex
+    bg-linear-to-r from-[#F5F4F7] to-purple-500
+    bg-clip-text text-transparent
+  ">
+    stellar
+  </p>
+</div>
+<ProgressLoader />
+    </div>
+  )
+}
+
+export default PageLoader

--- a/components/Loading/ProgressLoader.tsx
+++ b/components/Loading/ProgressLoader.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+const ProgressLoader = () => {
+  const [progress, setProgress] = useState(0)
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setProgress((prev) => {
+        if (prev >= 100) {
+          clearInterval(interval)
+          return 100
+        }
+        return prev + 1
+      })
+    }, 20)
+
+    return () => clearInterval(interval)
+  }, [])
+
+  return (
+    <div className="w-[20%] mx-auto h-1 bg-black/10 rounded-full overflow-hidden mt-4">
+      <div
+        className="h-full bg-[#b408b4]/50 transition-all duration-200 ease-out"
+        style={{ width: `${progress}%` }}
+      />
+    </div>
+  )
+}
+
+export default ProgressLoader


### PR DESCRIPTION
Issue #5 

I noticed a global styling overrides the use of margin and padding. Below I have attached two separate instances
- This app
<img width="1512" height="779" alt="Screenshot 2026-01-23 at 17 21 50" src="https://github.com/user-attachments/assets/3d1cf0a6-1e86-4aa7-953f-961ae73b73dd" />

- Separate instance
<img width="1512" height="864" alt="Screenshot 2026-01-23 at 17 19 43" src="https://github.com/user-attachments/assets/43609898-ccaf-4732-8def-fac70bfe918e" />

