### PR TITLE
[89] feat(connect): add manual address input as fallback when no wallet is detected

### DIFF
--- a/app/utils/walletConnect.ts
+++ b/app/utils/walletConnect.ts
@@ -16,12 +16,20 @@ declare global {
 }
 
 /**
- * Checks if Freighter wallet extension is installed
+ * Checks if the Freighter browser extension is available.
  */
 export const isFreighterInstalled = async (): Promise<boolean> => {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  if ("freighter" in window && window.freighter) {
+    return true;
+  }
+
   try {
     const result = await isConnected();
-    return !result.error && result.isConnected;
+    return !result.error;
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary
- Freighter connect is now the primary action with wallet extension detection
- Added "Enter address manually" fallback link with Stellar G-address validation
- Read-only mode banner on connect and loading when using a pasted address

Closes #89

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] Manual path validates address format and proceeds to loading
- [x] Freighter path sets wallet-connected (non read-only) mode