### PR TITLE
fix(share): include persona archetype name and image on share card

### DIFF
--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -12,6 +12,165 @@ export async function GET(req: NextRequest) {
     const persona = searchParams.get('persona') || 'Network Pioneer';
     const topVibe = searchParams.get('topVibe') || 'Steady';
     const vibePercentage = searchParams.get('vibePercentage') || '0';
+    // archetypeImage: relative path e.g. /archetypes/wizard.png
+    const archetypeImagePath = searchParams.get('archetypeImage') ||
+      `/archetypes/${persona.toLowerCase().replace(/^the\s+/, '').replace(/\s+/g, '-')}.png`;
+
+    // Fetch archetype image for embedding (edge runtime requires absolute URL)
+    const baseUrl = req.nextUrl.origin;
+    let archetypeImageSrc: string | null = null;
+    try {
+      const imgRes = await fetch(`${baseUrl}${archetypeImagePath}`);
+      if (imgRes.ok) {
+        const buf = await imgRes.arrayBuffer();
+        const mime = imgRes.headers.get('content-type') || 'image/png';
+        archetypeImageSrc = `data:${mime};base64,${Buffer.from(buf).toString('base64')}`;
+      }
+    } catch {
+      // image not found — render without it
+    }
+
+    return new ImageResponse(
+      (
+        <div
+          style={{
+            height: '100%',
+            width: '100%',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: '#000000',
+            backgroundImage: 'radial-gradient(circle at 50% 50%, rgba(5, 64, 32, 0.4) 0%, #000000 80%)',
+            color: 'white',
+            fontFamily: 'sans-serif',
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              width: '1000px',
+              height: '1000px',
+              border: '1px solid rgba(255, 255, 255, 0.2)',
+              borderRadius: '60px',
+              backgroundColor: 'rgba(5, 64, 32, 0.1)',
+              backgroundImage: 'linear-gradient(135deg, rgba(5, 64, 32, 0.2) 0%, rgba(0, 0, 0, 0.8) 100%)',
+              padding: '60px',
+              position: 'relative',
+              justifyContent: 'space-between',
+            }}
+          >
+            <div style={{ display: 'flex', flexDirection: 'column' }}>
+                <div style={{ display: 'flex', alignItems: 'center', marginBottom: '40px' }}>
+                <div style={{ width: '16px', height: '16px', borderRadius: '50%', backgroundColor: '#054020', marginRight: '24px' }} />
+                <span style={{ fontSize: '24px', fontWeight: 900, letterSpacing: '0.2em', color: 'rgba(255,255,255,0.7)' }}>
+                    STELLAR WRAPPED 2026
+                </span>
+                </div>
+                <h1 style={{ fontSize: '90px', fontWeight: 900, margin: 0, padding: 0, lineHeight: 1.1 }}>
+                @{username}
+                </h1>
+            </div>
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '30px', marginTop: '40px', marginBottom: '40px' }}>
+                <div style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    backgroundColor: 'rgba(255, 255, 255, 0.05)',
+                    borderRadius: '30px',
+                    padding: '40px',
+                    border: '1px solid rgba(255, 255, 255, 0.1)'
+                }}>
+                    <span style={{ fontSize: '28px', fontWeight: 700, color: 'rgba(255,255,255,0.6)', marginBottom: '15px' }}>
+                        Total Transactions
+                    </span>
+                    <span style={{ fontSize: '100px', fontWeight: 900, lineHeight: 1 }}>
+                        {transactions}
+                    </span>
+                </div>
+
+                {/* Persona — archetype image + bold name */}
+                <div style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    backgroundColor: 'rgba(255, 255, 255, 0.05)',
+                    borderRadius: '30px',
+                    padding: '40px',
+                    border: '1px solid rgba(255, 255, 255, 0.1)'
+                }}>
+                    <span style={{ fontSize: '28px', fontWeight: 700, color: 'rgba(255,255,255,0.6)', marginBottom: '20px' }}>
+                        Persona
+                    </span>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '30px' }}>
+                      {archetypeImageSrc && (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                          src={archetypeImageSrc}
+                          alt={persona}
+                          width={100}
+                          height={100}
+                          style={{ borderRadius: '20px', objectFit: 'cover', flexShrink: 0 }}
+                        />
+                      )}
+                      <span style={{
+                          fontSize: '60px',
+                          fontWeight: 900,
+                          color: 'white',
+                          lineHeight: 1.1,
+                      }}>
+                          {persona}
+                      </span>
+                    </div>
+                </div>
+
+                <div style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    backgroundColor: 'rgba(255, 255, 255, 0.05)',
+                    borderRadius: '30px',
+                    padding: '40px',
+                    border: '1px solid rgba(255, 255, 255, 0.1)'
+                }}>
+                    <span style={{ fontSize: '28px', fontWeight: 700, color: 'rgba(255,255,255,0.6)', marginBottom: '15px' }}>
+                        Top Vibe
+                    </span>
+                    <span style={{ fontSize: '50px', fontWeight: 900, color: 'white' }}>
+                        {vibePercentage}% {topVibe}
+                    </span>
+                </div>
+            </div>
+
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+              <span style={{ fontSize: '24px', fontWeight: 900, color: 'rgba(255,255,255,0.5)' }}>stellar.org/wrapped</span>
+              <div style={{
+                width: '80px',
+                height: '80px',
+                borderRadius: '24px',
+                border: '1px solid rgba(255, 255, 255, 0.2)',
+                backgroundColor: 'rgba(255, 255, 255, 0.1)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center'
+              }}>
+                <div style={{ width: '40px', height: '40px', borderRadius: '12px', backgroundColor: '#054020' }} />
+              </div>
+            </div>
+          </div>
+        </div>
+      ) as React.ReactElement,
+      {
+        width: 1200,
+        height: 1200,
+      }
+    );
+  } catch (e) {
+    if (e instanceof Error) {
+      console.error(e.message);
+    }
+    return new Response(`Failed to generate the image`, { status: 500 });
+  }
+}
 
     return new ImageResponse(
       (

--- a/app/components/ShareImageCard.tsx
+++ b/app/components/ShareImageCard.tsx
@@ -1,14 +1,20 @@
 "use client";
 
+import Image from "next/image";
 import { mockData } from "../data/mockData";
 
 interface ShareImageCardProps {
   themeColor: string;
+  archetypeImage?: string; // e.g. '/archetypes/wizard.png'
 }
 
-export function ShareImageCard({ themeColor }: ShareImageCardProps) {
+export function ShareImageCard({ themeColor, archetypeImage }: ShareImageCardProps) {
   const { persona, transactions, username, vibes } = mockData;
   const topVibe = vibes[0];
+  // Derive image from persona name if not explicitly provided: "The Wizard" -> /archetypes/wizard.png
+  const resolvedArchetypeImage =
+    archetypeImage ??
+    `/archetypes/${persona.toLowerCase().replace(/^the\s+/, "").replace(/\s+/g, "-")}.png`;
 
   // Convert any color format to rgb values for gradient
   const getRgbValues = (color: string): string => {
@@ -161,17 +167,25 @@ export function ShareImageCard({ themeColor }: ShareImageCardProps) {
             >
               Persona
             </p>
-            <p
-              style={{
-                fontSize: "30px",
-                fontWeight: "900",
-                WebkitBackgroundClip: "text",
-                WebkitTextFillColor: "transparent",
-                backgroundClip: "text",
-              }}
-            >
-              {persona}
-            </p>
+            <div style={{ display: "flex", alignItems: "center", gap: "16px" }}>
+              <Image
+                src={resolvedArchetypeImage}
+                alt={persona}
+                width={64}
+                height={64}
+                style={{ borderRadius: "12px", objectFit: "cover", flexShrink: 0 }}
+              />
+              <p
+                style={{
+                  fontSize: "30px",
+                  fontWeight: "900",
+                  color: "white",
+                  margin: 0,
+                }}
+              >
+                {persona}
+              </p>
+            </div>
           </div>
 
           {/* Top Vibe */}

--- a/app/share/page.tsx
+++ b/app/share/page.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Share2 } from "lucide-react";
 import { mockData } from "@/app/data/mockData";
+import { GOLDEN_USER } from "@/src/data/mockData";
 import { ProgressIndicator } from "@/app/components/ProgressIndicator";
 import { MuteToggle } from "../components/MuteToggle";
 import { ShareCard } from "../components/ShareCard";
@@ -100,7 +101,7 @@ export default function ShareCardPage() {
         className="absolute"
         style={{ left: "-9999px", top: 0 }}
       >
-        <ShareImageCard themeColor={themeColor} />
+        <ShareImageCard themeColor={themeColor} archetypeImage={GOLDEN_USER.archetype.image} />
       </div>
 
       <ShareCard


### PR DESCRIPTION
- ShareImageCard: add archetypeImage prop; render archetype image (64x64) beside persona name in large bold font; derive image path from persona name when prop not provided
- /api/og: accept archetypeImage query param; fetch image as base64 in edge runtime; render it at 100x100 alongside bold persona name (60px/900)
- share/page.tsx: pass GOLDEN_USER.archetype.image to ShareImageCard

Closes #107