### PR TITLE
feat(layout): add persistent navbar with wallet status indicator

### DIFF
--- a/app/components/AppNavbar.tsx
+++ b/app/components/AppNavbar.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { Navbar } from "./Navbar";
+
+const HIDDEN_PATHS = ["/"];
+
+export function AppNavbar() {
+  const pathname = usePathname();
+  if (HIDDEN_PATHS.includes(pathname)) return null;
+  return <Navbar />;
+}

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -1,12 +1,26 @@
-"use client"
+"use client";
 
-import Link from "next/link"
-import { ColorToggle } from "./ColorToggle"
-import { motion } from "framer-motion"
+import { useRouter } from "next/navigation";
+import { ColorToggle } from "./ColorToggle";
+import { motion } from "framer-motion";
+import { useWrapStore } from "@/app/store/wrapStore";
+import { LogOut } from "lucide-react";
+
+function truncate(addr: string) {
+  return `${addr.slice(0, 4)}…${addr.slice(-4)}`;
+}
 
 export function Navbar() {
+  const router = useRouter();
+  const { address, reset } = useWrapStore();
+
+  const handleDisconnect = () => {
+    reset();
+    router.push("/");
+  };
+
   return (
-    <motion.nav 
+    <motion.nav
       initial={{ y: -20, opacity: 0 }}
       animate={{ y: 0, opacity: 1 }}
       className="fixed top-0 left-0 right-0 z-50 px-6 py-4 flex items-center justify-between backdrop-blur-md bg-black/20 border-b border-white/5"
@@ -18,11 +32,25 @@ export function Navbar() {
         <span className="font-bold text-lg tracking-tight">Zimma</span>
       </div>
 
-      <div className="flex items-center gap-6">
-        <Link href="/features" className="text-sm text-neutral-400 hover:text-white transition-colors hidden sm:block">Features</Link>
-        <Link href="/about" className="text-sm text-neutral-400 hover:text-white transition-colors hidden sm:block">About</Link>
+      <div className="flex items-center gap-3">
         <ColorToggle />
+
+        {address && (
+          <>
+            <span className="text-xs font-mono text-neutral-300 bg-white/5 border border-white/10 rounded-full px-3 py-1">
+              {truncate(address)}
+            </span>
+            <button
+              onClick={handleDisconnect}
+              aria-label="Disconnect wallet"
+              className="flex items-center gap-1.5 text-xs text-neutral-400 hover:text-white border border-white/10 rounded-full px-3 py-1 hover:bg-white/5 transition-colors"
+            >
+              <LogOut size={12} />
+              Disconnect
+            </button>
+          </>
+        )}
       </div>
     </motion.nav>
-  )
+  );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import { DevTool } from "./components/DevTool";
 import { Toaster } from "sonner";
 import { SoundManager } from "./components/SoundManager";
 import { RateLimitBanner } from "./components/RateLimitBanner";
+import { AppNavbar } from "./components/AppNavbar";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -34,6 +35,7 @@ export default function RootLayout({
         suppressHydrationWarning
       >
         <Providers>
+          <AppNavbar />
           {children}
           <SoundManager />
           <RateLimitBanner />


### PR DESCRIPTION
- Navbar: shows truncated address (first 4 + last 4 chars) and Disconnect button when wallet is connected; disconnect resets store and redirects to landing page
- AppNavbar: client wrapper that hides navbar on '/' (landing page) and renders it on all other routes (/connect, /loading, /vibe-check, /persona, /share, etc.)
- layout.tsx: mounts AppNavbar inside Providers so it has store access

Closes #96