### PR TITLE
chore: add Husky pre-push hook to run type checking

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,14 +1,18 @@
 #!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
 
-echo "🏗  Running build before push..."
-npm run build
+echo "Running TypeScript type check before push..."
+echo "  Skip in an emergency: git push --no-verify"
+echo
+
+yarn tsc --noEmit --pretty
 
 status=$?
 
 if [ $status -ne 0 ]; then
   echo
-  echo "✖ Build failed. Fix errors before pushing to GitHub."
+  echo "✖ Type check failed. Fix the errors above before pushing."
+  echo "  Emergency bypass: git push --no-verify  (use sparingly)"
   exit $status
 fi
 
+echo "✓ Type check passed."


### PR DESCRIPTION
Replaces the slow `npm run build` (~2 min) with `yarn tsc --noEmit --pretty` (10-30s, incremental) so type errors are caught locally before CI. Fixes the package manager mismatch (npm → yarn) and drops the Husky v8 source line.
Closes #158