### PR TITLE
feat: resolve multiple assigned issues (keyboard nav, PNG download, step labels, rate-limit banner)

### DIFF
--- a/app/components/LandingPage.tsx
+++ b/app/components/LandingPage.tsx
@@ -441,9 +441,18 @@ export function LandingPage() {
               <motion.button
                 key={periodOption}
                 onClick={() => setSelectedPeriod(periodOption)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    setSelectedPeriod(periodOption);
+                  }
+                }}
                 className="relative px-4 py-2 sm:px-6 sm:py-3 md:px-8 md:py-4 rounded-lg md:rounded-xl font-black tracking-tight text-sm sm:text-base md:text-lg"
                 whileHover={{ scale: 1.05 }}
                 whileTap={{ scale: 0.98 }}
+                role="radio"
+                aria-checked={selectedPeriod === periodOption}
+                aria-label={`${periodOption} period`}
               >
                 {selectedPeriod === periodOption && (
                   <motion.div
@@ -472,6 +481,12 @@ export function LandingPage() {
         >
           <motion.button
             onClick={handleStart}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                handleStart();
+              }
+            }}
             className="relative group w-full"
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.98 }}

--- a/app/components/ShareButtons.tsx
+++ b/app/components/ShareButtons.tsx
@@ -68,6 +68,23 @@ export function ShareButtons({
     }
   };
 
+  const handleKeyDown = (platform: keyof typeof shareLinks) => (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      handleShare(platform);
+    }
+  };
+
+  const toggleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      setIsOpen(!isOpen);
+    }
+    if (e.key === "Escape" && isOpen) {
+      setIsOpen(false);
+    }
+  };
+
   const handleCopyLink = async () => {
     if (typeof window === 'undefined' || !shareUrl) return;
     try {
@@ -75,7 +92,6 @@ export function ShareButtons({
       setCopied(true);
       window.setTimeout(() => setCopied(false), 2000);
     } catch {
-      // Fallback for older browsers
       const textarea = document.createElement('textarea');
       textarea.value = shareUrl;
       textarea.style.position = 'fixed';
@@ -121,14 +137,18 @@ export function ShareButtons({
               backgroundColor: 'rgba(0, 0, 0, 0.8)',
               borderColor: 'rgba(138, 180, 248, 0.3)',
             }}
+            role="menu"
+            aria-label="Share options"
           >
             {/* X/Twitter */}
             <motion.button
               whileHover={{ scale: 1.05, x: 5 }}
               whileTap={{ scale: 0.95 }}
               onClick={() => handleShare('twitter')}
+              onKeyDown={handleKeyDown('twitter')}
               className="flex items-center gap-3 px-4 py-3 rounded-xl transition-all group"
               style={{ backgroundColor: 'rgba(138, 180, 248, 0.1)' }}
+              role="menuitem"
             >
               <div className="w-10 h-10 rounded-full flex items-center justify-center" style={{ backgroundColor: '#000000' }}>
                 <X className="w-5 h-5 text-white" />
@@ -141,8 +161,10 @@ export function ShareButtons({
               whileHover={{ scale: 1.05, x: 5 }}
               whileTap={{ scale: 0.95 }}
               onClick={() => handleShare('farcaster')}
+              onKeyDown={handleKeyDown('farcaster')}
               className="flex items-center gap-3 px-4 py-3 rounded-xl transition-all group"
               style={{ backgroundColor: 'rgba(138, 180, 248, 0.1)' }}
+              role="menuitem"
             >
               <div className="w-10 h-10 rounded-full flex items-center justify-center" style={{ backgroundColor: '#7959FF' }}>
                 <svg className="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 1000 1000" aria-hidden="true">
@@ -157,8 +179,10 @@ export function ShareButtons({
               whileHover={{ scale: 1.05, x: 5 }}
               whileTap={{ scale: 0.95 }}
               onClick={() => handleShare('whatsapp')}
+              onKeyDown={handleKeyDown('whatsapp')}
               className="flex items-center gap-3 px-4 py-3 rounded-xl transition-all group"
               style={{ backgroundColor: 'rgba(138, 180, 248, 0.1)' }}
+              role="menuitem"
             >
               <div className="w-10 h-10 rounded-full flex items-center justify-center" style={{ backgroundColor: '#25D366' }}>
                 <svg className="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24">
@@ -173,8 +197,10 @@ export function ShareButtons({
               whileHover={{ scale: 1.05, x: 5 }}
               whileTap={{ scale: 0.95 }}
               onClick={() => handleShare('facebook')}
+              onKeyDown={handleKeyDown('facebook')}
               className="flex items-center gap-3 px-4 py-3 rounded-xl transition-all group"
               style={{ backgroundColor: 'rgba(138, 180, 248, 0.1)' }}
+              role="menuitem"
             >
               <div className="w-10 h-10 rounded-full flex items-center justify-center" style={{ backgroundColor: '#1877F2' }}>
                 <svg className="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24">
@@ -189,8 +215,10 @@ export function ShareButtons({
               whileHover={{ scale: 1.05, x: 5 }}
               whileTap={{ scale: 0.95 }}
               onClick={() => handleShare('linkedin')}
+              onKeyDown={handleKeyDown('linkedin')}
               className="flex items-center gap-3 px-4 py-3 rounded-xl transition-all group"
               style={{ backgroundColor: 'rgba(138, 180, 248, 0.1)' }}
+              role="menuitem"
             >
               <div className="w-10 h-10 rounded-full flex items-center justify-center" style={{ backgroundColor: '#0A66C2' }}>
                 <svg className="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24">
@@ -205,8 +233,10 @@ export function ShareButtons({
               whileHover={{ scale: 1.05, x: 5 }}
               whileTap={{ scale: 0.95 }}
               onClick={() => handleShare('telegram')}
+              onKeyDown={handleKeyDown('telegram')}
               className="flex items-center gap-3 px-4 py-3 rounded-xl transition-all group"
               style={{ backgroundColor: 'rgba(138, 180, 248, 0.1)' }}
+              role="menuitem"
             >
               <div className="w-10 h-10 rounded-full flex items-center justify-center" style={{ backgroundColor: '#26A5E4' }}>
                 <svg className="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24">
@@ -242,8 +272,15 @@ export function ShareButtons({
                 whileHover={{ scale: 1.05, x: 5 }}
                 whileTap={{ scale: 0.95 }}
                 onClick={handleNativeShare}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    handleNativeShare();
+                  }
+                }}
                 className="flex items-center gap-3 px-4 py-3 rounded-xl transition-all group"
                 style={{ backgroundColor: 'rgba(138, 180, 248, 0.1)' }}
+                role="menuitem"
               >
                 <div className="w-10 h-10 rounded-full flex items-center justify-center" style={{ backgroundColor: '#8AB4F8' }}>
                   <Share2 className="w-5 h-5 text-white" />
@@ -257,6 +294,7 @@ export function ShareButtons({
         {/* Main share button */}
         <motion.button
           onClick={() => setIsOpen(!isOpen)}
+          onKeyDown={toggleKeyDown}
           className="w-14 h-14 sm:w-16 sm:h-16 rounded-full flex items-center justify-center backdrop-blur-xl border group relative overflow-hidden"
           style={{
             backgroundColor: isOpen ? 'rgba(0, 0, 0, 0.9)' : 'rgba(0, 0, 0, 0.8)',
@@ -264,6 +302,8 @@ export function ShareButtons({
           }}
           whileHover={{ scale: 1.1 }}
           whileTap={{ scale: 0.95 }}
+          aria-label="Share options"
+          aria-expanded={isOpen}
         >
           <motion.div
             className="absolute inset-0  from-transparent via-white/10 to-transparent"

--- a/app/components/ShareCard.tsx
+++ b/app/components/ShareCard.tsx
@@ -386,6 +386,12 @@ export function ShareCard({
             }}
             className={`w-full group relative mt-8 ${mintFailed ? "animate-pulse" : ""}`}
             onClick={handleMint}
+            onKeyDown={(e) => {
+              if ((e.key === "Enter" || e.key === " ") && !isMinting && !mintSuccess) {
+                e.preventDefault();
+                handleMint();
+              }
+            }}
             disabled={!isOnline || isMinting || !!mintSuccess}
           >
             <motion.div
@@ -464,6 +470,12 @@ export function ShareCard({
                 whileTap={{ scale: 0.98 }}
                 className="w-full group relative"
                 onClick={handleShareX}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    handleShareX();
+                  }
+                }}
               >
                 <motion.div
                   className="absolute -inset-1 rounded-2xl blur-xl opacity-0 group-hover:opacity-100 transition-opacity"
@@ -489,6 +501,12 @@ export function ShareCard({
                 whileTap={{ scale: 0.98 }}
                 className="w-full group relative"
                 onClick={handleShareX}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    handleShareX();
+                  }
+                }}
               >
                 <motion.div
                   className="absolute -inset-1 rounded-2xl blur-xl opacity-0 group-hover:opacity-100 transition-opacity"
@@ -521,6 +539,12 @@ export function ShareCard({
                 whileTap={{ scale: 0.98 }}
                 className="w-full group relative"
                 onClick={handleDownload}
+                onKeyDown={(e) => {
+                  if ((e.key === "Enter" || e.key === " ") && !isDownloading) {
+                    e.preventDefault();
+                    handleDownload();
+                  }
+                }}
                 disabled={isDownloading}
               >
                 <motion.div

--- a/app/components/ShareImageCard.tsx
+++ b/app/components/ShareImageCard.tsx
@@ -1,30 +1,28 @@
 "use client";
 
 import Image from "next/image";
+import { useState, type RefObject } from "react";
+import { Download } from "lucide-react";
+import html2canvas from "html2canvas";
 import { mockData } from "../data/mockData";
 
 interface ShareImageCardProps {
   themeColor: string;
-  archetypeImage?: string; // e.g. '/archetypes/wizard.png'
+  archetypeImage?: string;
 }
 
 export function ShareImageCard({ themeColor, archetypeImage }: ShareImageCardProps) {
   const { persona, transactions, username, vibes } = mockData;
   const topVibe = vibes[0];
-  // Derive image from persona name if not explicitly provided: "The Wizard" -> /archetypes/wizard.png
   const resolvedArchetypeImage =
     archetypeImage ??
     `/archetypes/${persona.toLowerCase().replace(/^the\s+/, "").replace(/\s+/g, "-")}.png`;
 
-  // Convert any color format to rgb values for gradient
   const getRgbValues = (color: string): string => {
-    // Handle rgb() format
     const rgbMatch = color.match(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/);
     if (rgbMatch) {
       return `${rgbMatch[1]}, ${rgbMatch[2]}, ${rgbMatch[3]}`;
     }
-
-    // Handle hex format
     if (color.startsWith("#")) {
       const hex = color.replace("#", "");
       const r = parseInt(hex.substring(0, 2), 16);
@@ -32,8 +30,6 @@ export function ShareImageCard({ themeColor, archetypeImage }: ShareImageCardPro
       const b = parseInt(hex.substring(4, 6), 16);
       return `${r}, ${g}, ${b}`;
     }
-
-    // Fallback
     return "29, 185, 84";
   };
 
@@ -49,7 +45,6 @@ export function ShareImageCard({ themeColor, archetypeImage }: ShareImageCardPro
         backgroundColor: "#020202",
       }}
     >
-      {/* Main card container matching ShareCard preview  */}
       <div
         style={{
           position: "relative",
@@ -62,7 +57,6 @@ export function ShareImageCard({ themeColor, archetypeImage }: ShareImageCardPro
           background: `linear-gradient(to bottom right, rgba(${rgbValues}, 0.2), rgba(0, 0, 0, 0.8))`,
         }}
       >
-        {/* Card header */}
         <div style={{ padding: "32px" }}>
           <div
             style={{
@@ -105,7 +99,6 @@ export function ShareImageCard({ themeColor, archetypeImage }: ShareImageCardPro
           </h2>
         </div>
 
-        {/* Stats */}
         <div
           style={{
             paddingLeft: "32px",
@@ -115,7 +108,6 @@ export function ShareImageCard({ themeColor, archetypeImage }: ShareImageCardPro
             gap: "16px",
           }}
         >
-          {/* Total Transactions */}
           <div
             style={{
               backdropFilter: "blur(4px)",
@@ -147,7 +139,6 @@ export function ShareImageCard({ themeColor, archetypeImage }: ShareImageCardPro
             </p>
           </div>
 
-          {/* Persona */}
           <div
             style={{
               backdropFilter: "blur(4px)",
@@ -188,7 +179,6 @@ export function ShareImageCard({ themeColor, archetypeImage }: ShareImageCardPro
             </div>
           </div>
 
-          {/* Top Vibe */}
           <div
             style={{
               backdropFilter: "blur(4px)",
@@ -220,7 +210,6 @@ export function ShareImageCard({ themeColor, archetypeImage }: ShareImageCardPro
           </div>
         </div>
 
-        {/* Footer */}
         <div
           style={{
             position: "absolute",
@@ -266,5 +255,74 @@ export function ShareImageCard({ themeColor, archetypeImage }: ShareImageCardPro
         </div>
       </div>
     </div>
+  );
+}
+
+interface DownloadPngButtonProps {
+  cardRef: RefObject<HTMLDivElement | null>;
+  address?: string;
+}
+
+export function DownloadPngButton({ cardRef, address }: DownloadPngButtonProps) {
+  const [isDownloading, setIsDownloading] = useState(false);
+
+  const handleDownload = async () => {
+    if (!cardRef.current || isDownloading) return;
+    setIsDownloading(true);
+    try {
+      const clone = cardRef.current.cloneNode(true) as HTMLElement;
+      clone.style.position = "absolute";
+      clone.style.left = "-9999px";
+      clone.style.top = "0";
+      document.body.appendChild(clone);
+
+      const canvas = await html2canvas(clone, {
+        scale: 3,
+        backgroundColor: "#020202",
+        useCORS: true,
+        allowTaint: true,
+        logging: false,
+        width: 1080,
+        height: 1080,
+      });
+
+      document.body.removeChild(clone);
+
+      const blob = await new Promise<Blob>((resolve, reject) => {
+        canvas.toBlob((b) => {
+          if (b) resolve(b);
+          else reject(new Error("Failed to generate image blob"));
+        }, "image/png", 1.0);
+      });
+
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      const addressShort = address ? address.slice(0, 8) : "unknown";
+      link.href = url;
+      link.download = `stellar-wrap-${addressShort}.png`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      setTimeout(() => URL.revokeObjectURL(url), 100);
+    } catch {
+      // Silently fail
+    } finally {
+      setIsDownloading(false);
+    }
+  };
+
+  return (
+    <button
+      onClick={handleDownload}
+      disabled={isDownloading}
+      className="flex cursor-pointer items-center pl-4 w-42 h-15 gap-3 p-2 rounded-xl bg-[#0F0F10] hover:bg-[#1a1a1c] transition-colors group"
+    >
+      <div className="h-10 w-10 flex items-center justify-center rounded-full bg-black border border-white/10">
+        <Download className={`w-5 h-5 text-white ${isDownloading ? "animate-pulse" : ""}`} />
+      </div>
+      <span className="font-bold text-white tracking-wide">
+        {isDownloading ? "Downloading..." : "Download PNG"}
+      </span>
+    </button>
   );
 }

--- a/app/components/StepProgressDisplay.tsx
+++ b/app/components/StepProgressDisplay.tsx
@@ -244,6 +244,12 @@ export function StepProgressDisplay({
                 {indexingError.recoverable && onRetry && (
                   <motion.button
                     onClick={onRetry}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        onRetry();
+                      }
+                    }}
                     whileHover={{ scale: 1.05 }}
                     whileTap={{ scale: 0.95 }}
                     className="flex items-center gap-2 px-4 py-2 bg-red-500/20 hover:bg-red-500/30 border border-red-500/30 rounded-lg text-sm font-medium text-red-300 transition-colors"
@@ -255,6 +261,12 @@ export function StepProgressDisplay({
                 {onCancel && (
                   <motion.button
                     onClick={onCancel}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        onCancel();
+                      }
+                    }}
                     whileHover={{ scale: 1.05 }}
                     whileTap={{ scale: 0.95 }}
                     className="flex items-center gap-2 px-4 py-2 bg-neutral-500/20 hover:bg-neutral-500/30 border border-neutral-500/30 rounded-lg text-sm font-medium text-neutral-300 transition-colors"

--- a/app/globals.css
+++ b/app/globals.css
@@ -34,3 +34,15 @@ body {
   -moz-osx-font-smoothing: grayscale;
   transition: background-color 200ms ease, color 200ms ease;
 }
+
+*:focus-visible {
+  outline: 2px solid var(--color-theme-primary) !important;
+  outline-offset: 2px !important;
+  border-radius: 4px;
+}
+
+button:focus:not(:focus-visible),
+a:focus:not(:focus-visible),
+[tabindex]:focus:not(:focus-visible) {
+  outline: none !important;
+}

--- a/app/loading/page.tsx
+++ b/app/loading/page.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useMemo } from "react";
 import { Home, ChevronRight } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { ProgressIndicator } from "../components/ProgressIndicator";
-import { IndexingSkeleton } from "../components/IndexingSkeleton";
+import { StepProgressDisplay } from "../components/StepProgressDisplay";
 import { CacheStatusBadge } from "../components/CacheStatusBadge";
 import { MuteToggle } from "../components/MuteToggle";
 import { useWrapStore, type WrapResult } from "../store/wrapStore";
@@ -277,9 +277,9 @@ export default function LoadingScreen() {
       {/* Container for centered layout with progress left and content right */}
       <div className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-40 w-full max-w-6xl px-4 pointer-events-auto">
         <div className="flex items-center justify-between gap-8">
-          {/* IndexingSkeleton - Enhanced progress display with visualizations */}
+          {/* StepProgressDisplay - Real-time indexing step progress with labels */}
           <div className="w-full md:w-full lg:max-w-3xl pointer-events-auto space-y-4">
-            <IndexingSkeleton
+            <StepProgressDisplay
               onCancel={handleCancel}
               onRetry={handleRetry}
             />
@@ -294,12 +294,19 @@ export default function LoadingScreen() {
 
       <motion.button
         onClick={() => router.push("/")}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            router.push("/");
+          }
+        }}
         className="absolute top-6 left-6 md:top-8 md:left-8 z-30 group"
         initial={{ opacity: 0, x: -20 }}
         animate={{ opacity: 1, x: 0 }}
         transition={{ delay: 0.2 }}
         whileHover={{ scale: 1.05 }}
         whileTap={{ scale: 0.95 }}
+        aria-label="Go home"
       >
         <div
           className="flex items-center gap-2 px-3 py-2 md:px-4 md:py-3 rounded-xl backdrop-blur-xl border border-white/20"
@@ -326,12 +333,20 @@ export default function LoadingScreen() {
           playSound(SOUND_NAMES.SLIDE_WHOOSH);
           handleComplete();
         }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            playSound(SOUND_NAMES.SLIDE_WHOOSH);
+            handleComplete();
+          }
+        }}
         className="absolute bottom-8 right-8 md:bottom-12 md:right-12 z-30 group"
         initial={{ opacity: 0, scale: 0.8 }}
         animate={{ opacity: 1, scale: 1 }}
         transition={{ delay: 1 }}
         whileHover={{ scale: 1.1 }}
         whileTap={{ scale: 0.95 }}
+        aria-label="Skip"
       >
         <div className="flex flex-col items-center gap-2">
           <div className="relative">

--- a/app/persona/page.tsx
+++ b/app/persona/page.tsx
@@ -196,6 +196,23 @@ export default function ArchetypeReveal(): JSX.Element {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [result]);
 
+  const handleShareKeyDown = (platform: string) => (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      handleShare(platform);
+    }
+  };
+
+  const toggleShareKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      setShareOpen(!shareOpen);
+    }
+    if (e.key === "Escape" && shareOpen) {
+      setShareOpen(false);
+    }
+  };
+
   // click-outside to close share menu
   useEffect(() => {
     const onDocClick = (e: MouseEvent) => {
@@ -211,8 +228,17 @@ export default function ArchetypeReveal(): JSX.Element {
         setShareOpen(false);
       }
     };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && shareOpen) {
+        setShareOpen(false);
+      }
+    };
     document.addEventListener("mousedown", onDocClick);
-    return () => document.removeEventListener("mousedown", onDocClick);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", onDocClick);
+      document.removeEventListener("keydown", onKeyDown);
+    };
   }, [shareOpen]);
 
   const triggerConfetti = useConfetti();
@@ -339,12 +365,19 @@ export default function ArchetypeReveal(): JSX.Element {
           {/* Home Button - Absolute positioned like share page */}
           <Link href="/">
             <motion.button
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  window.location.href = "/";
+                }
+              }}
               className="absolute top-6 left-6 md:top-8 md:left-8 z-30 group"
               initial={{ opacity: 0, x: -20 }}
               animate={{ opacity: 1, x: 0 }}
               transition={{ delay: 0.2 }}
               whileHover={{ scale: 1.05 }}
               whileTap={{ scale: 0.95 }}
+              aria-label="Go home"
             >
               <div
                 className="flex items-center gap-2 px-3 py-2 md:px-4 md:py-3 rounded-xl backdrop-blur-xl border border-white/20"
@@ -539,7 +572,9 @@ export default function ArchetypeReveal(): JSX.Element {
                     {/* X / Twitter */}{" "}
                     <button
                       onClick={() => handleShare("x")}
-                      className=" flex cursor-pointer items-center pl-6 w-42 h-15 gap-3 p-2 rounded-xl bg-[#0F0F10] hover:bg-[#1a1a1c] transition-colors group"
+                      onKeyDown={handleShareKeyDown("x")}
+                      className="flex cursor-pointer items-center pl-6 w-42 h-15 gap-3 p-2 rounded-xl bg-[#0F0F10] hover:bg-[#1a1a1c] transition-colors group"
+                      role="menuitem"
                     >
                       {" "}
                       <div className="flex items-center gap-3 relative left-5">
@@ -557,7 +592,9 @@ export default function ArchetypeReveal(): JSX.Element {
                     {/* WhatsApp */}{" "}
                     <button
                       onClick={() => handleShare("whatsapp")}
+                      onKeyDown={handleShareKeyDown("whatsapp")}
                       className="flex items-center cursor-pointer justify-center gap-3 p-2 w-42 h-15 rounded-xl bg-[#0F0F10] hover:bg-[#1a1a1c] transition-colors"
+                      role="menuitem"
                     >
                       {" "}
                       <div className="flex h-10 w-10 items-center justify-center rounded-full bg-[#25D366]">
@@ -572,7 +609,9 @@ export default function ArchetypeReveal(): JSX.Element {
                     {/* Facebook */}{" "}
                     <button
                       onClick={() => handleShare("facebook")}
+                      onKeyDown={handleShareKeyDown("facebook")}
                       className="flex items-center cursor-pointer justify-center gap-3 p-2 w-42 h-15 rounded-xl bg-[#0F0F10] hover:bg-[#1a1a1c] transition-colors"
+                      role="menuitem"
                     >
                       {" "}
                       <div className="flex h-10 w-10 items-center justify-center rounded-full bg-[#1877F2]">
@@ -587,7 +626,9 @@ export default function ArchetypeReveal(): JSX.Element {
                     {/* LinkedIn */}{" "}
                     <button
                       onClick={() => handleShare("linkedin")}
+                      onKeyDown={handleShareKeyDown("linkedin")}
                       className="flex items-center justify-center cursor-pointer gap-3 p-2 w-42 h-15 rounded-xl bg-[#0F0F10] hover:bg-[#1a1a1c] transition-colors"
+                      role="menuitem"
                     >
                       {" "}
                       <div className="flex h-10 w-10 items-center justify-center rounded-full bg-[#0077B5]">
@@ -602,7 +643,9 @@ export default function ArchetypeReveal(): JSX.Element {
                     {/* Telegram */}{" "}
                     <button
                       onClick={() => handleShare("telegram")}
+                      onKeyDown={handleShareKeyDown("telegram")}
                       className="flex items-center cursor-pointer justify-center gap-3 p-2 w-42 h-15 rounded-xl bg-[#0F0F10] hover:bg-[#1a1a1c] transition-colors"
+                      role="menuitem"
                     >
                       {" "}
                       <div className="flex h-10 w-10 items-center justify-center rounded-full bg-[#229ED9]">
@@ -621,7 +664,10 @@ export default function ArchetypeReveal(): JSX.Element {
               <button
                 ref={shareBtnRef}
                 onClick={() => setShareOpen(!shareOpen)}
+                onKeyDown={toggleShareKeyDown}
                 className="flex h-12 w-12 sm:h-16 sm:w-16 items-center justify-center rounded-full border border-white/10 bg-black/60 text-white backdrop-blur-md transition hover:bg-white/5"
+                aria-label="Share"
+                aria-expanded={shareOpen}
               >
                 <motion.div
                   animate={{ rotate: shareOpen ? 50 : 0 }}
@@ -636,12 +682,19 @@ export default function ArchetypeReveal(): JSX.Element {
           {/* Skip/Next Button - Absolute positioned like share page */}
           <Link href="/share">
             <motion.button
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  window.location.href = "/share";
+                }
+              }}
               className="absolute bottom-6 right-6 md:bottom-8 md:right-8 z-30 group"
               initial={{ opacity: 0, scale: 0.8 }}
               animate={{ opacity: 1, scale: 1 }}
               transition={{ delay: 1 }}
               whileHover={{ scale: 1.1 }}
               whileTap={{ scale: 0.95 }}
+              aria-label="Next step"
             >
               <div className="flex h-12 w-12 sm:h-16 sm:w-16 items-center justify-center rounded-full border border-white/10 bg-black/60 text-white backdrop-blur-md transition hover:bg-white/5">
                 <ChevronRight className="h-6 w-6 sm:h-9 sm:w-9" />

--- a/app/services/indexerRecoveryService.ts
+++ b/app/services/indexerRecoveryService.ts
@@ -3,6 +3,7 @@ import { IndexerEventEmitter } from "@/app/utils/indexerEventEmitter";
 import { STEP_ORDER, type IndexingStep } from "@/app/types/indexing";
 import type { IndexerResult, WrapPeriod } from "@/app/utils/indexer";
 import { indexerErrorLogger } from "@/app/utils/indexerErrorLogger";
+import { useRateLimitStore } from "@/src/store/rateLimitStore";
 import {
   backoffDelay,
   classifyError,
@@ -174,6 +175,8 @@ export class IndexerRecoveryService {
       this.state.totalRetries,
     );
 
+    useRateLimitStore.getState().reset();
+
     return (this.partialResults["finalizing"] as IndexerResult) ?? null;
   }
 
@@ -215,6 +218,7 @@ export class IndexerRecoveryService {
       return this.continueFrom(STEP_ORDER[nextIdx], opts);
     }
 
+    useRateLimitStore.getState().reset();
     this.state.pendingAction = null;
     this.emit();
     return (this.partialResults["finalizing"] as IndexerResult) ?? null;
@@ -268,6 +272,8 @@ export class IndexerRecoveryService {
       this.state.isPartial,
       this.state.totalRetries,
     );
+
+    useRateLimitStore.getState().reset();
 
     return (this.partialResults["finalizing"] as IndexerResult) ?? null;
   }

--- a/app/share/page.tsx
+++ b/app/share/page.tsx
@@ -8,7 +8,7 @@ import { GOLDEN_USER } from "@/src/data/mockData";
 import { ProgressIndicator } from "@/app/components/ProgressIndicator";
 import { MuteToggle } from "../components/MuteToggle";
 import { ShareCard } from "../components/ShareCard";
-import { ShareImageCard } from "../components/ShareImageCard";
+import { ShareImageCard, DownloadPngButton } from "../components/ShareImageCard";
 import { PersonaEvolutionTimeline } from "../components/PersonaEvolutionTimeline";
 import { useTheme, themeColors } from "../context/ThemeContext";
 import { useWrapStore } from "../store/wrapStore";
@@ -56,6 +56,23 @@ export default function ShareCardPage() {
     return computedColor || themeColors[color].primary;
   });
 
+  const handleShareKeyDown = (platform: string) => (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      handleShare(platform);
+    }
+  };
+
+  const toggleShareKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      setShareOpen(!shareOpen);
+    }
+    if (e.key === "Escape" && shareOpen) {
+      setShareOpen(false);
+    }
+  };
+
   // --- Share Functionality ---
   const handleShare = (platform: string) => {
     const url = window.location.href;
@@ -98,8 +115,17 @@ export default function ShareCardPage() {
         setShareOpen(false);
       }
     };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && shareOpen) {
+        setShareOpen(false);
+      }
+    };
     document.addEventListener("mousedown", onDocClick);
-    return () => document.removeEventListener("mousedown", onDocClick);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", onDocClick);
+      document.removeEventListener("keydown", onKeyDown);
+    };
   }, [shareOpen]);
 
   return (
@@ -169,7 +195,9 @@ export default function ShareCardPage() {
                 {/* X / Twitter */}
                 <button
                   onClick={() => handleShare("x")}
+                  onKeyDown={handleShareKeyDown("x")}
                   className="flex cursor-pointer items-center pl-4 w-42 h-15 gap-3 p-2 rounded-xl bg-[#0F0F10] hover:bg-[#1a1a1c] transition-colors group"
+                  role="menuitem"
                 >
                   <div className="h-10 w-10 flex items-center justify-center rounded-full bg-black border border-white/10">
                     <SocialIcons.X />
@@ -178,8 +206,10 @@ export default function ShareCardPage() {
                 </button>
 
                 <button
-                  onClick={() => handleShare("x")}
+                  onClick={() => handleShare("whatsapp")}
+                  onKeyDown={handleShareKeyDown("whatsapp")}
                   className="flex cursor-pointer items-center pl-4 w-42 h-15 gap-3 p-2 rounded-xl bg-[#0F0F10] hover:bg-[#1a1a1c] transition-colors group"
+                  role="menuitem"
                 >
                   <div className="flex h-10 w-10 items-center justify-center rounded-full bg-[#25D366]">
                     <SocialIcons.WhatsApp />
@@ -191,7 +221,9 @@ export default function ShareCardPage() {
 
                 <button
                   onClick={() => handleShare("facebook")}
+                  onKeyDown={handleShareKeyDown("facebook")}
                   className="flex items-center cursor-pointer pl-4 gap-3 p-2 w-42 h-15 rounded-xl bg-[#0F0F10] hover:bg-[#1a1a1c] transition-colors"
+                  role="menuitem"
                 >
                   <div className="flex h-10 w-10 items-center justify-center rounded-full bg-[#1877F2]">
                     <SocialIcons.Facebook />
@@ -203,7 +235,9 @@ export default function ShareCardPage() {
 
                 <button
                   onClick={() => handleShare("linkedin")}
+                  onKeyDown={handleShareKeyDown("linkedin")}
                   className="flex items-center pl-4 cursor-pointer gap-3 p-2 w-42 h-15 rounded-xl bg-[#0F0F10] hover:bg-[#1a1a1c] transition-colors"
+                  role="menuitem"
                 >
                   <div className="flex h-10 w-10 items-center justify-center rounded-full bg-[#0077B5]">
                     <SocialIcons.LinkedIn />
@@ -215,7 +249,9 @@ export default function ShareCardPage() {
 
                 <button
                   onClick={() => handleShare("telegram")}
+                  onKeyDown={handleShareKeyDown("telegram")}
                   className="flex items-center cursor-pointer pl-4 gap-3 p-2 w-42 h-15 rounded-xl bg-[#0F0F10] hover:bg-[#1a1a1c] transition-colors"
+                  role="menuitem"
                 >
                   <div className="flex h-10 w-10 items-center justify-center rounded-full bg-[#229ED9]">
                     <SocialIcons.Telegram />
@@ -224,6 +260,10 @@ export default function ShareCardPage() {
                     Telegram
                   </span>
                 </button>
+
+                <div className="w-full border-t border-white/10 my-1" />
+
+                <DownloadPngButton cardRef={shareImageRef} address={walletAddress ?? undefined} />
               </motion.div>
             )}
           </AnimatePresence>
@@ -231,7 +271,10 @@ export default function ShareCardPage() {
           <button
             ref={shareBtnRef}
             onClick={() => setShareOpen(!shareOpen)}
+            onKeyDown={toggleShareKeyDown}
             className="flex h-12 w-12 sm:h-16 sm:w-16 items-center justify-center rounded-full border border-white/10 bg-black/60 text-white backdrop-blur-md transition hover:bg-white/5"
+            aria-label="Share"
+            aria-expanded={shareOpen}
           >
             <motion.div
               animate={{ rotate: shareOpen ? 50 : 0 }}

--- a/src/utils/__tests__/indexerRecovery.test.ts
+++ b/src/utils/__tests__/indexerRecovery.test.ts
@@ -8,6 +8,7 @@ import {
   BASE_BACKOFF_MS,
 } from "@/app/types/indexingRecovery";
 import { STEP_ORDER } from "@/app/types/indexing";
+import { useRateLimitStore } from "@/src/store/rateLimitStore";
 
 
 describe("classifyError", () => {
@@ -118,6 +119,58 @@ describe("MAX_RETRIES", () => {
   });
 });
 
+
+describe("RateLimitStore banner visibility", () => {
+  beforeEach(() => {
+    useRateLimitStore.getState().reset();
+  });
+
+  it("initial state has banner hidden (isRateLimited false, retryAttempt 0)", () => {
+    const state = useRateLimitStore.getState();
+    expect(state.isRateLimited).toBe(false);
+    expect(state.retryAttempt).toBe(0);
+  });
+
+  it("reset clears isRateLimited and retryAttempt", () => {
+    useRateLimitStore.getState().setRateLimited(true, Date.now() + 10000);
+    useRateLimitStore.getState().setRetryAttempt(3);
+    useRateLimitStore.getState().setMessage("Rate limited");
+
+    useRateLimitStore.getState().reset();
+
+    const state = useRateLimitStore.getState();
+    expect(state.isRateLimited).toBe(false);
+    expect(state.retryAttempt).toBe(0);
+    expect(state.message).toBeNull();
+  });
+
+  it("banner visibility condition (isRateLimited || retryAttempt > 0) is false after reset", () => {
+    useRateLimitStore.getState().setRateLimited(true, Date.now() + 10000);
+    useRateLimitStore.getState().setRetryAttempt(3);
+
+    useRateLimitStore.getState().reset();
+
+    const { isRateLimited, retryAttempt } = useRateLimitStore.getState();
+    const showBanner = isRateLimited || retryAttempt > 0;
+    expect(showBanner).toBe(false);
+  });
+
+  it("banner visibility condition is true when rate limited", () => {
+    useRateLimitStore.getState().setRateLimited(true, Date.now() + 10000);
+
+    const { isRateLimited, retryAttempt } = useRateLimitStore.getState();
+    const showBanner = isRateLimited || retryAttempt > 0;
+    expect(showBanner).toBe(true);
+  });
+
+  it("banner visibility condition is true during retry", () => {
+    useRateLimitStore.getState().setRetryAttempt(2);
+
+    const { isRateLimited, retryAttempt } = useRateLimitStore.getState();
+    const showBanner = isRateLimited || retryAttempt > 0;
+    expect(showBanner).toBe(true);
+  });
+});
 
 describe("STEP_ORDER", () => {
   it("starts with initializing", () => {


### PR DESCRIPTION
## Summary

Resolves all four issues assigned to me in a single PR.

### Issues Resolved

- **Closes #80** - Rate-limit banner auto-dismisses after indexer recovery
- **Closes #82** - Download share card as PNG button in ShareImageCard
- **Closes #88** - Real-time indexing step progress with labels
- **Closes #90** - Keyboard navigation support throughout the full wrap flow

### Changes

#### #80 - Rate-limit Banner Auto-Dismiss
- Added `useRateLimitStore.getState().reset()` calls on successful completion in `IndexerRecoveryService` (`runFrom`, `continueFrom`, `retryFailedStep`)
- Banner hides automatically when indexing finishes without error
- Added test coverage for banner visibility conditions

#### #82 - Download Share Card as PNG
- Added `DownloadPngButton` component exported from `ShareImageCard.tsx`
- Integrated into share page floating menu with visual separator
- Captures the card at 3x resolution using `html2canvas`
- Filename defaults to `stellar-wrap-{address-short}.png`

#### #88 - Indexing Step Progress Labels
- Replaced `IndexingSkeleton` with `StepProgressDisplay` in loading page
- Each step shows readable label from `INDEXING_STEPS` config
- Current step label visible below progress bar
- Completed steps show checkmark (✓)
- Smooth framer-motion transitions between steps

#### #90 - Keyboard Navigation
- Added visible focus ring styles (`focus-visible`) to `globals.css`
- Added `onKeyDown` handlers (Enter/Space) to all interactive elements
- Escape key closes share menus in all pages
- Added ARIA attributes: `role`, `aria-label`, `aria-expanded`, `aria-checked`, `role="menuitem"`
- Affected components: period selector, CTA button, share buttons (3 locations), Home/Skip buttons, loading page controls, ShareCard actions, persona card