### PR TITLE
chore(ci): add Lighthouse CI scores tracking (#156)

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,57 @@
+name: Lighthouse CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  lighthouse:
+    name: Lighthouse Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build Next.js app
+        run: yarn build
+
+      - name: Run Lighthouse CI
+        run: yarn lhci autorun
+        env:
+          LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+
+      - name: Upload Lighthouse reports (artifact)
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: lighthouse-reports-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .lighthouseci/
+          retention-days: 90
+
+      - name: Upload Lighthouse reports (PR comment)
+        uses: treosh/lighthouse-ci-action@v12
+        if: github.event_name == 'pull_request'
+        with:
+          configPath: './lighthouserc.json'
+          uploadArtifacts: true
+          temporaryPublicStorage: true

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 > **Turn your ledger data into social proof. A shareable, monthly summary of your impact on the Stellar network.**
 
 ![Stellar Wrap Landing Page](./public/stellar-wrap.png)
+[![Lighthouse CI](https://github.com/zintarh/stellar-wrap-frontend/actions/workflows/lighthouse.yml/badge.svg)](https://github.com/zintarh/stellar-wrap-frontend/actions/workflows/lighthouse.yml)
 
 ---
 
@@ -86,6 +87,7 @@ Copy `.env.example` to `.env.local` and set:
 
 Contract addresses are loaded per network; the app uses the selected network (mainnet/testnet) to choose the contract. When you switch networks in the UI, the contract instance is re-loaded for the new network.
 
+```markdown
 ### Running tests
 
 ```bash
@@ -100,7 +102,14 @@ rm -rf node_modules && npm install
 npm test
 ```
 
+### Running Lighthouse locally
+
+```bash
+yarn build
+yarn lhci:local
 ---
+
+See [TESTING.md](./TESTING.md) for full Lighthouse CI documentation, score thresholds, and troubleshooting.
 
 ## 🗺️ Roadmap
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -2,6 +2,33 @@
 
 This document provides information about running and maintaining tests for the Stellar Wrap project.
 
+## Lighthouse CI (Performance & Quality)
+
+We use [Lighthouse CI](https://github.com/GoogleChrome/lighthouse-ci) to track Performance, Accessibility, Best Practices, and SEO scores on every pull request.
+
+### Score Thresholds
+
+| Category | Minimum Score | Enforcement |
+|----------|-------------|-------------|
+| Performance | 70 | Hard fail (PR blocked) |
+| Accessibility | 85 | Hard fail (PR blocked) |
+| Best Practices | 90 | Hard fail (PR blocked) |
+| SEO | 80 | Hard fail (PR blocked) |
+
+### Running Lighthouse Locally
+
+Useful for debugging performance regressions before opening a PR:
+
+```bash
+# 1. Install dependencies (if not already done)
+yarn install
+
+# 2. Build the production app
+yarn build
+
+# 3. Run Lighthouse CI against the local production server
+yarn lhci:local
+
 ## Quick Start
 
 ```bash

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,51 @@
+{
+  "ci": {
+    "collect": {
+      "startServerCommand": "yarn start",
+      "url": [
+        "http://localhost:3000/",
+        "http://localhost:3000/connect",
+        "http://localhost:3000/share"
+      ],
+      "numberOfRuns": 3,
+      "settings": {
+        "preset": "perf",
+        "formFactor": "mobile",
+        "screenEmulation": {
+          "mobile": true,
+          "width": 390,
+          "height": 844,
+          "deviceScaleFactor": 3,
+          "disabled": false
+        },
+        "onlyCategories": [
+          "performance",
+          "accessibility",
+          "best-practices",
+          "seo"
+        ],
+        "skipAudits": [
+          "uses-http2",
+          "canonical",
+          "is-on-https"
+        ]
+      }
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["error", { "minScore": 0.70 }],
+        "categories:accessibility": ["error", { "minScore": 0.85 }],
+        "categories:best-practices": ["error", { "minScore": 0.90 }],
+        "categories:seo": ["error", { "minScore": 0.80 }],
+        "first-contentful-paint": ["warn", { "maxNumericValue": 3000 }],
+        "largest-contentful-paint": ["warn", { "maxNumericValue": 4000 }],
+        "total-blocking-time": ["warn", { "maxNumericValue": 600 }],
+        "cumulative-layout-shift": ["warn", { "maxNumericValue": 0.15 }]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage",
+      "githubAppToken": "${LHCI_GITHUB_APP_TOKEN}"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "vitest": "vitest",
     "test:ui": "vitest --ui",
     "test": "npx jest",
+    "lhci": "lhci autorun",
+    "lhci:local": "lhci autorun --config=./lighthouserc.json",
     "prepare": "husky install"
   },
   "dependencies": {
@@ -34,6 +36,7 @@
     "zustand": "^5.0.10"
   },
   "devDependencies": {
+    "@lhci/cli": "^0.14.0",
     "@tailwindcss/postcss": "^4",
     "@types/canvas-confetti": "^1.9.0",
     "@types/jest": "^29.5.14",


### PR DESCRIPTION
# PR Description: Add Lighthouse CI Scores Tracking
## Description
Fixes #156

This PR adds automated Lighthouse CI performance and quality tracking to prevent score regressions from going unnoticed as features are added to the client-heavy SPA.

### Changes Included
- Installed and configured `@lhci/cli` (Lighthouse CI) with `lighthouserc.json`.
- Added a GitHub Actions CI job that runs Lighthouse on every PR and push to `main`.
- Audits 3 key pages: `/`, `/connect`, `/share` using mobile preset (390×844, DPR 3).
- Set minimum score thresholds with hard-fail assertions:
  - Performance ≥ 70
  - Accessibility ≥ 85
  - Best Practices ≥ 90
  - SEO ≥ 80
- Added Core Web Vitals warning thresholds (non-blocking):
  - FCP ≤ 3,000 ms, LCP ≤ 4,000 ms, TBT ≤ 600 ms, CLS ≤ 0.15
- Configured 3 runs per URL for stable median scoring.
- Uploaded reports as GitHub Actions artifacts (90-day retention) and temporary public storage for PR comment links.
- Added `lhci` and `lhci:local` scripts to `package.json` for convenience.
- Documented local Lighthouse debugging workflow in `TESTING.md`.
- Added CI status badge and quick-reference section to `README.md`.