### PR TITLE
docs: add API route documentation with request/response examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,96 @@ pnpm test
 
 See [TESTING.md](./TESTING.md) for full Lighthouse CI documentation, score thresholds, and troubleshooting.
 
+## 📡 API Reference
+
+The application exposes two HTTP API routes. A machine-readable [OpenAPI 3.1 spec](./openapi.yaml) is also available.
+
+TypeScript request/response types live in [`src/types/api.ts`](./src/types/api.ts).
+
+---
+
+### `GET /api/wrapped`
+
+Returns aggregated on-chain statistics for a Stellar address.
+
+**Query parameters**
+
+| Parameter   | Type     | Required | Default    | Description |
+|-------------|----------|----------|------------|-------------|
+| `accountId` | `string` | ✅ Yes   | —          | Stellar public key (56 chars, starts with `G`) |
+| `network`   | `string` | No       | `mainnet`  | `mainnet` or `testnet` |
+| `period`    | `string` | No       | `monthly`  | `weekly`, `monthly`, or `yearly` |
+
+**Cache behaviour**: Results are cached in IndexedDB for 60 minutes. Subsequent requests within that window return `cached: true` and may trigger a background re-index (`refreshingInBackground: true`).
+
+**Example request**
+
+```bash
+curl "https://stellar-wrap.vercel.app/api/wrapped?accountId=GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN&network=mainnet&period=monthly"
+```
+
+**Example response (200)**
+
+```json
+{
+  "username": "alice.stellar",
+  "address": "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+  "totalTransactions": 142,
+  "totalVolume": 58432.5,
+  "percentile": 87,
+  "persona": "The DeFi Patron",
+  "personaDescription": "You move capital with purpose across Stellar's DEX.",
+  "dapps": [
+    { "name": "Stellar DEX", "transactions": 80, "color": "#6366f1", "gradient": "linear-gradient(135deg,#6366f1,#8b5cf6)" }
+  ],
+  "vibes": [
+    { "type": "Power User", "percentage": 72, "color": "#f59e0b", "label": "Power User" }
+  ],
+  "cached": false,
+  "cacheTimestamp": null,
+  "refreshingInBackground": false
+}
+```
+
+**Error responses**
+
+| Status | Meaning |
+|--------|---------|
+| `400`  | Missing or invalid `accountId`, `network`, or `period` |
+| `404`  | Account not found on the specified network |
+| `429`  | Horizon rate limit exceeded — retry after a short delay |
+| `500`  | Unexpected server or Horizon error |
+
+---
+
+### `GET /api/og`
+
+Returns a **1200 × 1200 PNG** share card image, rendered on Vercel Edge Runtime.
+
+**Query parameters**
+
+| Parameter       | Type     | Required | Default             | Description |
+|-----------------|----------|----------|---------------------|-------------|
+| `username`      | `string` | No       | `StellarUser`       | Username shown on the card |
+| `transactions`  | `string` | No       | `0`                 | Total transaction count |
+| `persona`       | `string` | No       | `Network Pioneer`   | Archetype label |
+| `topVibe`       | `string` | No       | `Steady`            | Top vibe label |
+| `vibePercentage`| `string` | No       | `0`                 | Top vibe percentage (0–100) |
+| `archetypeImage`| `string` | No       | *(derived)*         | Path to archetype image under `/public` |
+
+**Cache**: `Cache-Control: public, s-maxage=86400, stale-while-revalidate=604800` — CDN-cached for 24 h, stale-while-revalidate for 7 days.
+
+**Example request**
+
+```bash
+curl -o share-card.png \
+  "https://stellar-wrap.vercel.app/api/og?username=alice&transactions=142&persona=The+DeFi+Patron&topVibe=Power+User&vibePercentage=72"
+```
+
+**Response**: Binary PNG (`Content-Type: image/png`).
+
+---
+
 ## 🗺️ Roadmap
 
 Our immediate focus is on delivering a polished MVP for the community:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,327 @@
+openapi: "3.1.0"
+info:
+  title: Stellar Wrap API
+  version: "1.0.0"
+  description: |
+    API routes exposed by the Stellar Wrap Next.js application.
+
+    Two public endpoints are available:
+    - **GET /api/wrapped** — returns aggregated on-chain statistics for a Stellar address.
+    - **GET /api/og** — returns a 1200 × 1200 PNG share card (served from Vercel Edge Runtime).
+
+servers:
+  - url: https://stellar-wrap.vercel.app
+    description: Production
+  - url: http://localhost:3000
+    description: Local development
+
+paths:
+  /api/wrapped:
+    get:
+      operationId: getWrapped
+      summary: Get aggregated wrap data for a Stellar account
+      description: |
+        Fetches and indexes on-chain transaction history for the given Stellar
+        address and returns aggregated statistics for the requested period.
+
+        **Caching**: Results are cached in IndexedDB for 60 minutes.
+        Subsequent requests within that window return `cached: true` and may
+        trigger a background re-index (`refreshingInBackground: true`).
+
+        **Rate limiting**: Horizon may respond with HTTP 429. The server
+        propagates this as a 429 response to the caller.
+      parameters:
+        - name: accountId
+          in: query
+          required: true
+          description: Stellar public key (56 characters, starting with "G").
+          schema:
+            type: string
+            pattern: "^G[A-Z2-7]{55}$"
+            example: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN"
+        - name: network
+          in: query
+          required: false
+          description: Stellar network to query. Defaults to `mainnet`.
+          schema:
+            type: string
+            enum: [mainnet, testnet]
+            default: mainnet
+        - name: period
+          in: query
+          required: false
+          description: Reporting period. Defaults to `monthly`.
+          schema:
+            type: string
+            enum: [weekly, monthly, yearly]
+            default: monthly
+      responses:
+        "200":
+          description: Successfully indexed account statistics.
+          headers:
+            Cache-Control:
+              description: No server-side cache; IndexedDB caching is handled client-side.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WrappedResponse"
+              example:
+                username: "alice.stellar"
+                address: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN"
+                totalTransactions: 142
+                totalVolume: 58432.5
+                percentile: 87
+                persona: "The DeFi Patron"
+                personaDescription: "You move capital with purpose across Stellar's DEX."
+                dapps:
+                  - name: "Stellar DEX"
+                    transactions: 80
+                    color: "#6366f1"
+                    gradient: "linear-gradient(135deg,#6366f1,#8b5cf6)"
+                vibes:
+                  - type: "Power User"
+                    percentage: 72
+                    color: "#f59e0b"
+                    label: "Power User"
+                cached: false
+                cacheTimestamp: null
+                refreshingInBackground: false
+        "400":
+          description: Missing or invalid request parameters.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              examples:
+                missingAccountId:
+                  value:
+                    error: "Missing accountId parameter"
+                invalidFormat:
+                  value:
+                    error: "Invalid account ID format"
+                invalidNetwork:
+                  value:
+                    error: "Invalid network"
+                invalidPeriod:
+                  value:
+                    error: "Invalid period"
+        "404":
+          description: Account not found on the specified network.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: "Account not found on this network"
+                details: "Make sure you selected the correct network (mainnet/testnet) where the account exists"
+        "429":
+          description: Horizon rate limit exceeded. Retry after a short delay.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: "Rate limited. Please try again later."
+        "500":
+          description: Unexpected server or Horizon error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: "Failed to fetch wrapped data"
+                details: "Horizon server error"
+
+  /api/og:
+    get:
+      operationId: getOgImage
+      summary: Generate a 1200 × 1200 PNG share card
+      description: |
+        Runs on **Vercel Edge Runtime** and returns a binary PNG image
+        suitable for use as an Open Graph / social media share card.
+
+        **Cache**: `Cache-Control: public, s-maxage=86400, stale-while-revalidate=604800`
+        — the CDN caches the image for 24 hours and can serve stale content for
+        up to 7 days while revalidating in the background.
+
+        The image is also called by social media crawlers when the page URL is
+        shared on X, Facebook, WhatsApp, etc.
+      parameters:
+        - name: username
+          in: query
+          required: false
+          description: Stellar username or truncated address shown on the card.
+          schema:
+            type: string
+            default: StellarUser
+            example: "alice.stellar"
+        - name: transactions
+          in: query
+          required: false
+          description: Total transaction count (stringified integer).
+          schema:
+            type: string
+            default: "0"
+            example: "142"
+        - name: persona
+          in: query
+          required: false
+          description: Persona / archetype label displayed on the card.
+          schema:
+            type: string
+            default: "Network Pioneer"
+            example: "The DeFi Patron"
+        - name: topVibe
+          in: query
+          required: false
+          description: Top vibe label (e.g. "Steady", "Power User").
+          schema:
+            type: string
+            default: Steady
+            example: "Power User"
+        - name: vibePercentage
+          in: query
+          required: false
+          description: Percentage for the top vibe (0–100, stringified).
+          schema:
+            type: string
+            default: "0"
+            example: "72"
+        - name: archetypeImage
+          in: query
+          required: false
+          description: |
+            Path to the archetype image relative to the app's public directory.
+            Defaults to a slug derived from the `persona` parameter.
+          schema:
+            type: string
+            example: "/archetypes/defi-patron.png"
+      responses:
+        "200":
+          description: 1200 × 1200 PNG share card image.
+          headers:
+            Cache-Control:
+              description: CDN caching directive.
+              schema:
+                type: string
+                example: "public, s-maxage=86400, stale-while-revalidate=604800"
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+        "500":
+          description: Image generation failed.
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "Failed to generate the image"
+
+components:
+  schemas:
+    WrappedDapp:
+      type: object
+      required: [name, transactions, color, gradient]
+      properties:
+        name:
+          type: string
+          example: "Stellar DEX"
+        transactions:
+          type: integer
+          example: 80
+        color:
+          type: string
+          example: "#6366f1"
+        gradient:
+          type: string
+          example: "linear-gradient(135deg,#6366f1,#8b5cf6)"
+
+    WrappedVibe:
+      type: object
+      required: [type, percentage, color, label]
+      properties:
+        type:
+          type: string
+          example: "Power User"
+        percentage:
+          type: number
+          minimum: 0
+          maximum: 100
+          example: 72
+        color:
+          type: string
+          example: "#f59e0b"
+        label:
+          type: string
+          example: "Power User"
+
+    WrappedResponse:
+      type: object
+      required:
+        - username
+        - address
+        - totalTransactions
+        - totalVolume
+        - percentile
+        - persona
+        - personaDescription
+        - dapps
+        - vibes
+        - cached
+        - cacheTimestamp
+        - refreshingInBackground
+      properties:
+        username:
+          type: string
+          example: "alice.stellar"
+        address:
+          type: string
+          example: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN"
+        totalTransactions:
+          type: integer
+          example: 142
+        totalVolume:
+          type: number
+          example: 58432.5
+        percentile:
+          type: number
+          minimum: 0
+          maximum: 100
+          example: 87
+        persona:
+          type: string
+          example: "The DeFi Patron"
+        personaDescription:
+          type: string
+          example: "You move capital with purpose across Stellar's DEX."
+        dapps:
+          type: array
+          items:
+            $ref: "#/components/schemas/WrappedDapp"
+        vibes:
+          type: array
+          items:
+            $ref: "#/components/schemas/WrappedVibe"
+        cached:
+          type: boolean
+          description: True when served from the 60-minute IndexedDB cache.
+        cacheTimestamp:
+          type: string
+          format: date-time
+          nullable: true
+          description: ISO-8601 creation time of the cache entry, or null.
+        refreshingInBackground:
+          type: boolean
+          description: True when a background re-index has been triggered.
+
+    ErrorResponse:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: string
+        details:
+          type: string

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,113 @@
+/**
+ * Type definitions for Stellar Wrap API request and response shapes.
+ *
+ * Used by both the frontend (typed fetch calls) and documentation tooling
+ * (OpenAPI codegen, mock servers, etc.).
+ */
+
+// ---------------------------------------------------------------------------
+// Shared primitives
+// ---------------------------------------------------------------------------
+
+/** Stellar public key — 56-character string starting with "G". */
+export type StellarAddress = string;
+
+/** Supported Stellar networks. */
+export type Network = "mainnet" | "testnet";
+
+/** Reporting period for wrap data. */
+export type WrapPeriod = "weekly" | "monthly" | "yearly";
+
+// ---------------------------------------------------------------------------
+// GET /api/wrapped
+// ---------------------------------------------------------------------------
+
+/** Query parameters accepted by GET /api/wrapped. */
+export interface WrappedRequestParams {
+  /** Required. A valid Stellar public key (56 chars, starts with "G"). */
+  accountId: StellarAddress;
+  /** Optional. Defaults to "mainnet". */
+  network?: Network;
+  /** Optional. Defaults to "monthly". */
+  period?: WrapPeriod;
+}
+
+/** A single dApp interaction entry returned by /api/wrapped. */
+export interface WrappedDapp {
+  name: string;
+  transactions: number;
+  color: string;
+  gradient: string;
+}
+
+/** A single vibe entry returned by /api/wrapped. */
+export interface WrappedVibe {
+  type: string;
+  percentage: number;
+  color: string;
+  label: string;
+}
+
+/** Successful 200 response body from GET /api/wrapped. */
+export interface WrappedResponse {
+  username: string;
+  address: StellarAddress;
+  totalTransactions: number;
+  totalVolume: number;
+  percentile: number;
+  persona: string;
+  personaDescription: string;
+  dapps: WrappedDapp[];
+  vibes: WrappedVibe[];
+  /** True when this response was served from the 60-minute IndexedDB cache. */
+  cached: boolean;
+  /** ISO-8601 timestamp of when the cache entry was created, or null. */
+  cacheTimestamp: string | null;
+  /** True when a background re-index has been triggered for this address. */
+  refreshingInBackground: boolean;
+}
+
+/** Error response body returned for 4xx / 5xx from GET /api/wrapped. */
+export interface WrappedErrorResponse {
+  error: string;
+  details?: string;
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/og
+// ---------------------------------------------------------------------------
+
+/** Query parameters accepted by GET /api/og. */
+export interface OgRequestParams {
+  /** Stellar username or truncated address shown on the card. Defaults to "StellarUser". */
+  username?: string;
+  /** Total transaction count displayed on the card. Defaults to "0". */
+  transactions?: string;
+  /** Persona / archetype label. Defaults to "Network Pioneer". */
+  persona?: string;
+  /** Top vibe label (e.g. "Steady", "Power User"). Defaults to "Steady". */
+  topVibe?: string;
+  /** Vibe percentage as a string (0–100). Defaults to "0". */
+  vibePercentage?: string;
+  /**
+   * Path to the archetype image relative to the app's public directory.
+   * Defaults to a slug derived from the persona name.
+   * Example: "/archetypes/wizard.png"
+   */
+  archetypeImage?: string;
+}
+
+/**
+ * The /api/og endpoint returns a binary PNG image (1200 × 1200 px), not JSON.
+ * This type represents the HTTP response metadata.
+ */
+export interface OgResponseMeta {
+  /** Always "image/png". */
+  contentType: "image/png";
+  /** Always 1200. */
+  width: 1200;
+  /** Always 1200. */
+  height: 1200;
+  /** Cache-Control header value set on the response. */
+  cacheControl: string;
+}


### PR DESCRIPTION
## Summary

Adds complete documentation for the two public API routes.

### Changes

- **`src/types/api.ts`** — TypeScript types for both endpoints:
  - `WrappedRequestParams`, `WrappedResponse`, `WrappedDapp`, `WrappedVibe`, `WrappedErrorResponse`
  - `OgRequestParams`, `OgResponseMeta`
  - Shared primitives: `StellarAddress`, `Network`, `WrapPeriod`

- **`openapi.yaml`** — OpenAPI 3.1 machine-readable spec covering:
  - `GET /api/wrapped`: all query params, 200/400/404/429/500 responses, full JSON schema, curl example
  - `GET /api/og`: all query params, 200 (binary PNG) / 500 responses, cache-control header docs

- **`README.md`** — New "📡 API Reference" section with:
  - Query parameter tables for both routes
  - `curl` examples
  - Example JSON response for `/api/wrapped`
  - Error status table
  - Cache behavior notes

## Validation

TypeScript file has no syntax errors; OpenAPI YAML is valid per spec structure.

Closes #153