### PR TITLE
ci: add typecheck script and workflow step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+      - name: Type check
+        run: pnpm typecheck
+
       - name: Build
         run: pnpm build
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -45,6 +45,16 @@ npm run test:watch
 npm run test:coverage
 ```
 
+## Type Checking
+
+Run the TypeScript compiler in `--noEmit` mode to catch type errors without emitting build output:
+
+```bash
+pnpm typecheck
+```
+
+This runs automatically in CI on every pull request.
+
 ## Test Infrastructure
 
 ### Framework

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev": "next dev",
     "start": "next start",
     "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
     "test:visual": "playwright test",
     "test:visual:update": "playwright test --update-snapshots",
     "vitest": "vitest",


### PR DESCRIPTION
## Summary
- Add a `typecheck` npm script (`tsc --noEmit`) to `package.json`
- Run it as a CI step (`.github/workflows/ci.yml`, `build-and-lint` job, before `Build`)
- Document the command in `TESTING.md`

Closes #305

## Heads up: pre-existing type errors on `main`
Running `pnpm typecheck` against current `main` surfaces ~35 syntax errors across 9 files (e.g. `app/components/Navbar.tsx`, `app/components/ShareCard.tsx`, `app/[locale]/connect/page.tsx`, `app/providers.tsx`, `app/utils/walletConnect.ts`) — mostly unclosed JSX tags / unbalanced braces. These aren't introduced by this PR; they're invisible to `next build` because Next only type-checks files reachable from actual routes, while `tsc --noEmit` checks every file matched by `tsconfig.json`. Merging this as-is will make the new CI step fail on `main` until those files are fixed. Happy to open a follow-up issue/PR for that cleanup, or fold it into this one if preferred — kept it separate here to avoid scope creep into files I didn't touch.

## Test plan
- [x] `pnpm typecheck` runs and reports errors (confirms the script is wired correctly)
- [ ] Pre-existing type errors in the files listed above get fixed (tracked separately, not in this PR)