### PR TITLE
fix: emitter reset, reduced motion, empty state, explorer link

### DIFF
--- a/app/[locale]/persona/page.tsx
+++ b/app/[locale]/persona/page.tsx
@@ -3,14 +3,22 @@
 import React, { JSX, useCallback, useEffect, useRef, useState } from "react";
 import { PersonaRarityChart } from "@/app/components/PersonaRarityChart";
 import { motion, useAnimation, AnimatePresence } from "framer-motion";
-import { Home, Share2, ChevronRight, X } from "lucide-react";
+import { Home, Share2, ChevronRight, X, ExternalLink } from "lucide-react";
 import Link from "next/link";
 import { readStreamableValue } from "ai/rsc";
 import { getArchetypeDescription } from "@/data/archetypeConfig";
+import {
+  useReducedMotion,
+  reducedMotionTransition,
+} from "@/app/hooks/useReducedMotion";
+import { isZeroActivityResult } from "@/app/utils/zeroActivity";
+import { ZeroActivityEmptyState } from "@/app/components/ZeroActivityEmptyState";
+import { getStellarExpertAccountUrl } from "@/app/utils/stellarExpert";
 
 // Removed theme system - using standard CSS variables from globals.css
-const useConfetti = (color?: string) => {
+const useConfetti = (color?: string, enabled = true) => {
   return async () => {
+    if (!enabled) return;
     // canvas-confetti (~40 KB) is loaded on demand — only when the card reveal
     // animation fires — so it never enters the initial landing-page bundle.
     const confetti = (await import("canvas-confetti")).default;
@@ -36,23 +44,36 @@ const useConfetti = (color?: string) => {
   };
 };
 
-type GlowingStarProps = { className?: string; delay?: number };
+type GlowingStarProps = {
+  className?: string;
+  delay?: number;
+  reducedMotion?: boolean;
+};
 const GlowingStar: React.FC<GlowingStarProps> = ({
   className = "",
   delay = 0,
+  reducedMotion = false,
 }) => (
   <motion.div
     initial={{ opacity: 0.2, scale: 0.8 }}
-    animate={{
-      opacity: [0.4, 1, 0.4],
-      scale: [0.8, 1.2, 0.8],
-      boxShadow: [
-        "0 0 5px var(--accent)",
-        "0 0 15px var(--accent-light)",
-        "0 0 5px var(--accent)",
-      ],
-    }}
-    transition={{ duration: 3, repeat: Infinity, delay }}
+    animate={
+      reducedMotion
+        ? { opacity: 0.7, scale: 1 }
+        : {
+            opacity: [0.4, 1, 0.4],
+            scale: [0.8, 1.2, 0.8],
+            boxShadow: [
+              "0 0 5px var(--accent)",
+              "0 0 15px var(--accent-light)",
+              "0 0 5px var(--accent)",
+            ],
+          }
+    }
+    transition={reducedMotionTransition(reducedMotion, {
+      duration: 3,
+      repeat: Infinity,
+      delay,
+    })}
     className={`absolute h-1.5 w-1.5 rounded-full ${className}`}
     style={{ backgroundColor: "var(--color-theme-primary)" }}
   />
@@ -127,6 +148,7 @@ const SocialIcons = {
 
 export default function ArchetypeReveal(): JSX.Element {
   const controls: ReturnType<typeof useAnimation> = useAnimation();
+  const prefersReducedMotion = useReducedMotion();
   const [isFlipped, setIsFlipped] = useState<boolean>(false);
   const [streamedDescription, setStreamedDescription] = useState<string>("");
   const [showTooltip, setShowTooltip] = useState<boolean>(false);
@@ -141,7 +163,9 @@ export default function ArchetypeReveal(): JSX.Element {
   const tooltipRef = useRef<HTMLDivElement | null>(null);
   const cardRef = useRef<HTMLDivElement | null>(null);
 
-  const { result } = useWrapStore();
+  const { result, address, network } = useWrapStore();
+  const stellarExpertUrl = getStellarExpertAccountUrl(address, network);
+  const showZeroActivity = isZeroActivityResult(result);
   const notificationStore = useNotificationStore();
   const [showNotifPrompt, setShowNotifPrompt] = useState<boolean>(true);
   const archetypeKey = result?.persona || "The Wizard";
@@ -256,7 +280,7 @@ export default function ArchetypeReveal(): JSX.Element {
     };
   }, [shareOpen, showTooltip]);
 
-  const triggerConfetti = useConfetti();
+  const triggerConfetti = useConfetti(undefined, !prefersReducedMotion);
 
   const runRevealAnimation = useCallback(async () => {
     setIsFlipped(false);
@@ -269,24 +293,31 @@ export default function ArchetypeReveal(): JSX.Element {
       y: 0,
       scale: 1,
       opacity: 1,
-      transition: { duration: 0.8, type: "spring" },
+      transition: prefersReducedMotion
+        ? { duration: 0 }
+        : { duration: 0.8, type: "spring" },
     });
 
     playSound(SOUND_NAMES.CARD_FLIP);
-    await controls.start({
-      x: [0, -4, 4, -4, 4, 0],
-      rotateZ: [0, -1, 1, -1, 1, 0],
-      transition: { duration: 0.4 },
-    });
+
+    if (!prefersReducedMotion) {
+      await controls.start({
+        x: [0, -4, 4, -4, 4, 0],
+        rotateZ: [0, -1, 1, -1, 1, 0],
+        transition: { duration: 0.4 },
+      });
+    }
 
     setIsFlipped(true);
     await triggerConfetti();
 
     await controls.start({
       rotateY: 180,
-      transition: { duration: 0.8, ease: "easeInOut" },
+      transition: prefersReducedMotion
+        ? { duration: 0 }
+        : { duration: 0.8, ease: "easeInOut" },
     });
-  }, [controls, playSound, triggerConfetti]);
+  }, [controls, playSound, prefersReducedMotion, triggerConfetti]);
 
   useEffect(() => {
     runRevealAnimation();
@@ -327,6 +358,30 @@ export default function ArchetypeReveal(): JSX.Element {
     setShareOpen(false);
   };
 
+  if (showZeroActivity) {
+    return (
+      <div
+        className="w-full bg-[#020202] md:min-h-screen flex items-center justify-center"
+        style={{ WebkitTapHighlightColor: "transparent", touchAction: "pan-y" }}
+      >
+        <ProgressIndicator currentStep={5} totalSteps={6} showNext={false} />
+        <ZeroActivityEmptyState />
+        {stellarExpertUrl && (
+          <a
+            href={stellarExpertUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="absolute bottom-6 left-6 z-30 flex items-center gap-2 px-4 py-3 rounded-xl backdrop-blur-xl border border-white/10 text-white/60 hover:text-white/90 hover:border-white/30 transition-all text-xs font-medium"
+            style={{ backgroundColor: "rgba(0, 0, 0, 0.5)" }}
+          >
+            <ExternalLink className="w-3.5 h-3.5" aria-hidden="true" />
+            View history on Stellar.expert
+          </a>
+        )}
+      </div>
+    );
+  }
+
   return (
     <>
       <div
@@ -348,7 +403,7 @@ export default function ArchetypeReveal(): JSX.Element {
               style={{ background: "var(--accent-dark)" }}
             />
 
-            {[...Array(20)].map((_, i) => (
+            {!prefersReducedMotion && [...Array(20)].map((_, i) => (
               <motion.div
                 key={i}
                 className="absolute left-1/2 top-1/2 rounded-full border"
@@ -458,10 +513,12 @@ export default function ArchetypeReveal(): JSX.Element {
             <GlowingStar
               className="-top-6 sm:-top-12 left-4 sm:left-10"
               delay={0.2}
+              reducedMotion={prefersReducedMotion}
             />
             <GlowingStar
               className="-top-6 sm:-top-12 right-4 sm:right-10"
               delay={0.5}
+              reducedMotion={prefersReducedMotion}
             />
 
             <motion.div
@@ -520,18 +577,22 @@ export default function ArchetypeReveal(): JSX.Element {
                 <GlowingStar
                   className="top-1/4 left-8 sm:left-16"
                   delay={0.1}
+                  reducedMotion={prefersReducedMotion}
                 />
                 <GlowingStar
                   className="bottom-1/4 left-12 sm:left-24"
                   delay={0.8}
+                  reducedMotion={prefersReducedMotion}
                 />
                 <GlowingStar
                   className="top-1/3 right-10 sm:right-20"
                   delay={0.4}
+                  reducedMotion={prefersReducedMotion}
                 />
                 <GlowingStar
                   className="bottom-1/3 right-8 sm:right-16"
                   delay={1.2}
+                  reducedMotion={prefersReducedMotion}
                 />
 
                 <div
@@ -759,6 +820,21 @@ export default function ArchetypeReveal(): JSX.Element {
             </div>
           </div>
 
+          {/* Transaction history explorer — hidden when address is missing */}
+          {stellarExpertUrl && (
+            <a
+              href={stellarExpertUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="absolute bottom-6 left-6 md:bottom-8 md:left-8 z-30 flex items-center gap-2 px-4 py-3 rounded-xl backdrop-blur-xl border border-white/10 text-white/60 hover:text-white/90 hover:border-white/30 transition-all text-xs font-medium"
+              style={{ backgroundColor: "rgba(0, 0, 0, 0.5)" }}
+              data-testid="persona-stellar-expert-link"
+            >
+              <ExternalLink className="w-3.5 h-3.5" aria-hidden="true" />
+              View history on Stellar.expert
+            </a>
+          )}
+
           {/* Skip/Next Button - Absolute positioned like share page */}
           <Link href="/share" aria-label="Go to share step">
             <motion.button
@@ -770,11 +846,13 @@ export default function ArchetypeReveal(): JSX.Element {
               }}
               className="absolute bottom-6 right-6 md:bottom-8 md:right-8 z-30 group"
               aria-label="Go to share step"
-              initial={{ opacity: 0, scale: 0.8 }}
+              initial={prefersReducedMotion ? false : { opacity: 0, scale: 0.8 }}
               animate={{ opacity: 1, scale: 1 }}
-              transition={{ delay: 1 }}
-              whileHover={{ scale: 1.1 }}
-              whileTap={{ scale: 0.95 }}
+              transition={reducedMotionTransition(prefersReducedMotion, {
+                delay: 1,
+              })}
+              whileHover={prefersReducedMotion ? undefined : { scale: 1.1 }}
+              whileTap={prefersReducedMotion ? undefined : { scale: 0.95 }}
               aria-label="Next step"
             >
               <div className="flex h-12 w-12 sm:h-16 sm:w-16 items-center justify-center rounded-full border border-white/10 bg-black/60 text-white backdrop-blur-md transition hover:bg-white/5">

--- a/app/[locale]/share/SharePageClient.tsx
+++ b/app/[locale]/share/SharePageClient.tsx
@@ -20,6 +20,13 @@ import {
   TelegramIcon,
 } from "../components/SocialIcons";
 import { trackEvent } from "../../utils/plausible";
+import { getStellarExpertAccountUrl } from "@/app/utils/stellarExpert";
+import { isZeroActivityResult } from "@/app/utils/zeroActivity";
+import { ZeroActivityEmptyState } from "@/app/components/ZeroActivityEmptyState";
+import {
+  useReducedMotion,
+  reducedMotionTransition,
+} from "@/app/hooks/useReducedMotion";
 
 const SocialIcons = {
   X: XIcon,
@@ -37,6 +44,7 @@ export default function SharePageClient() {
   const shareBtnRef = useRef<HTMLButtonElement | null>(null);
   const shareImageRef = useRef<HTMLDivElement>(null!);
   const { color } = useTheme();
+  const prefersReducedMotion = useReducedMotion();
   const { address: walletAddress, network, result } = useWrapStore();
 
   const username = result?.username ?? mockData.username;
@@ -45,11 +53,8 @@ export default function SharePageClient() {
   const topVibe = result?.vibes[0]?.label ?? mockData.vibes[0].label;
   const vibePercentage = result?.vibes[0]?.percentage ?? mockData.vibes[0].percentage;
 
-  const stellarExpertUrl = walletAddress
-    ? network === "testnet"
-      ? `https://stellar.expert/explorer/testnet/account/${walletAddress}`
-      : `https://stellar.expert/explorer/public/account/${walletAddress}`
-    : null;
+  const stellarExpertUrl = getStellarExpertAccountUrl(walletAddress, network);
+  const showZeroActivity = isZeroActivityResult(result);
 
   const [themeColor] = useState<string>(() => {
     if (typeof window === "undefined") return themeColors.green.primary;
@@ -118,6 +123,25 @@ export default function SharePageClient() {
 
   return (
     <div className="relative w-full h-screen overflow-hidden">
+      {showZeroActivity ? (
+        <div className="relative z-20 flex h-full items-center justify-center">
+          <ProgressIndicator currentStep={6} totalSteps={6} showNext={false} />
+          <ZeroActivityEmptyState />
+          {stellarExpertUrl && (
+            <a
+              href={stellarExpertUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="absolute bottom-6 right-6 md:bottom-8 md:right-8 z-30 flex items-center gap-2 px-4 py-3 rounded-xl backdrop-blur-xl border border-white/10 text-white/60 hover:text-white/90 hover:border-white/30 transition-all text-xs font-medium"
+              style={{ backgroundColor: "rgba(0, 0, 0, 0.5)" }}
+            >
+              <ExternalLink className="w-3.5 h-3.5" aria-hidden="true" />
+              View full history on Stellar.expert
+            </a>
+          )}
+        </div>
+      ) : (
+        <>
       <div
         ref={shareImageRef}
         className="absolute"
@@ -146,9 +170,9 @@ export default function SharePageClient() {
 
       <motion.div
         className="absolute top-6 right-6 md:top-8 md:right-8 z-30"
-        initial={{ opacity: 0, x: 20 }}
+        initial={prefersReducedMotion ? false : { opacity: 0, x: 20 }}
         animate={{ opacity: 1, x: 0 }}
-        transition={{ delay: 0.2 }}
+        transition={reducedMotionTransition(prefersReducedMotion, { delay: 0.2 })}
       >
         <MuteToggle />
       </motion.div>
@@ -160,9 +184,9 @@ export default function SharePageClient() {
           rel="noopener noreferrer"
           className="absolute bottom-6 right-6 md:bottom-8 md:right-8 z-30 flex items-center gap-2 px-4 py-3 rounded-xl backdrop-blur-xl border border-white/10 text-white/60 hover:text-white/90 hover:border-white/30 transition-all text-xs font-medium"
           style={{ backgroundColor: "rgba(0, 0, 0, 0.5)" }}
-          initial={{ opacity: 0, x: 20 }}
+          initial={prefersReducedMotion ? false : { opacity: 0, x: 20 }}
           animate={{ opacity: 1, x: 0 }}
-          transition={{ delay: 0.4 }}
+          transition={reducedMotionTransition(prefersReducedMotion, { delay: 0.4 })}
         >
           <ExternalLink className="w-3.5 h-3.5" />
           View full history on Stellar.expert
@@ -175,10 +199,10 @@ export default function SharePageClient() {
             {shareOpen && (
               <motion.div
                 ref={shareMenuRef}
-                initial={{ opacity: 0, y: 10, scale: 0.95 }}
+                initial={prefersReducedMotion ? false : { opacity: 0, y: 10, scale: 0.95 }}
                 animate={{ opacity: 1, y: 0, scale: 1 }}
-                exit={{ opacity: 0, y: 10, scale: 0.95 }}
-                transition={{ duration: 0.2 }}
+                exit={prefersReducedMotion ? undefined : { opacity: 0, y: 10, scale: 0.95 }}
+                transition={reducedMotionTransition(prefersReducedMotion, { duration: 0.2 })}
                 className="absolute bottom-18 left-0 w-[200px] h-[350px] bg-[#060607] border border-[#232325] rounded-2xl shadow-2xl p-2 z-50 flex flex-col items-center justify-center gap-2"
                 style={{ boxShadow: "0 10px 40px rgba(0,0,0,0.8)" }}
               >
@@ -250,13 +274,19 @@ export default function SharePageClient() {
           >
             <motion.div
               animate={{ rotate: shareOpen ? 50 : 0 }}
-              transition={{ type: "spring", stiffness: 260, damping: 20 }}
+              transition={
+                prefersReducedMotion
+                  ? { duration: 0 }
+                  : { type: "spring", stiffness: 260, damping: 20 }
+              }
             >
               <Share2 className="h-5 w-5 sm:h-7 sm:w-7 cursor-pointer" />
             </motion.div>
           </button>
         </div>
       </div>
+        </>
+      )}
     </div>
   );
 }

--- a/app/components/LandingPage.tsx
+++ b/app/components/LandingPage.tsx
@@ -11,9 +11,11 @@ import { CommunityWrapsCarousel } from './CommunityWrapsCarousel';
 import ParticleField from './ParticleField';
 import { LiveWrapCounter } from './LiveWrapCounter';
 import { useWrapStore, WrapPeriod } from '../store/wrapStore';
+import { useReducedMotion, reducedMotionTransition } from '../hooks/useReducedMotion';
 
 export function LandingPage() {
   const router = useRouter();
+  const prefersReducedMotion = useReducedMotion();
   const { period, setPeriod, reset, network } = useWrapStore();
   const [selectedPeriod, setSelectedPeriod] = useState<WrapPeriod>(period);
   
@@ -52,61 +54,75 @@ export function LandingPage() {
         style={{
           backgroundImage: 'repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(var(--color-theme-primary-rgb), 0.03) 2px, rgba(var(--color-theme-primary-rgb), 0.03) 4px)',
         }}
-        animate={{
-          backgroundPosition: ['0px 0px', '0px 4px'],
-        }}
-        transition={{
+        animate={
+          prefersReducedMotion
+            ? undefined
+            : { backgroundPosition: ['0px 0px', '0px 4px'] }
+        }
+        transition={reducedMotionTransition(prefersReducedMotion, {
           duration: 0.1,
           repeat: Infinity,
           ease: "linear"
-        }}
+        })}
       />
 
       {/* Multiple layered glows for depth */}
       <motion.div
         className="absolute top-0 left-1/2 -translate-x-1/2 w-[1200px] h-[800px] rounded-full blur-[200px]"
         style={{ backgroundColor: 'rgba(var(--color-theme-primary-rgb), 0.1)' }}
-        animate={{
-          scale: [1, 1.1, 1],
-          opacity: [0.1, 0.2, 0.1],
-        }}
-        transition={{
+        animate={
+          prefersReducedMotion
+            ? { opacity: 0.15, scale: 1 }
+            : {
+                scale: [1, 1.1, 1],
+                opacity: [0.1, 0.2, 0.1],
+              }
+        }
+        transition={reducedMotionTransition(prefersReducedMotion, {
           duration: 8,
           repeat: Infinity,
           ease: "easeInOut"
-        }}
+        })}
       />
 
       <motion.div
         className="absolute bottom-0 left-1/4 w-[800px] h-[600px] rounded-full blur-[180px]"
         style={{ backgroundColor: 'rgba(var(--color-theme-primary-rgb), 0.08)' }}
-        animate={{
-          scale: [1, 1.2, 1],
-          opacity: [0.1, 0.15, 0.1],
-        }}
-        transition={{
+        animate={
+          prefersReducedMotion
+            ? { opacity: 0.1, scale: 1 }
+            : {
+                scale: [1, 1.2, 1],
+                opacity: [0.1, 0.15, 0.1],
+              }
+        }
+        transition={reducedMotionTransition(prefersReducedMotion, {
           duration: 10,
           repeat: Infinity,
           ease: "easeInOut"
-        }}
+        })}
       />
 
       <motion.div
         className="absolute top-1/3 right-1/4 w-[600px] h-[600px] rounded-full blur-[160px]"
         style={{ backgroundColor: 'rgba(var(--color-theme-primary-rgb), 0.06)' }}
-        animate={{
-          scale: [1, 1.15, 1],
-          opacity: [0.08, 0.12, 0.08],
-        }}
-        transition={{
+        animate={
+          prefersReducedMotion
+            ? { opacity: 0.08, scale: 1 }
+            : {
+                scale: [1, 1.15, 1],
+                opacity: [0.08, 0.12, 0.08],
+              }
+        }
+        transition={reducedMotionTransition(prefersReducedMotion, {
           duration: 12,
           repeat: Infinity,
           ease: "easeInOut"
-        }}
+        })}
       />
 
       {/* Floating blockchain nodes (geometric shapes) */}
-      {[...Array(8)].map((_, i) => (
+      {!prefersReducedMotion && [...Array(8)].map((_, i) => (
         <motion.div
           key={i}
           className="absolute hidden md:block"
@@ -137,6 +153,7 @@ export function LandingPage() {
       ))}
 
       {/* Blockchain connection lines */}
+      {!prefersReducedMotion && (
       <svg className="absolute inset-0 w-full h-full pointer-events-none opacity-20 hidden md:block">
         {[...Array(6)].map((_, i) => {
           const x1 = 20 + i * 15;
@@ -167,8 +184,10 @@ export function LandingPage() {
           );
         })}
       </svg>
+      )}
 
       {/* Animated block chain visualization */}
+      {!prefersReducedMotion && (
       <div className="absolute left-4 md:left-12 top-1/2 -translate-y-1/2 hidden sm:block">
         {[...Array(5)].map((_, i) => (
           <motion.div
@@ -210,8 +229,10 @@ export function LandingPage() {
           </motion.div>
         ))}
       </div>
+      )}
 
       {/* Animated transaction flow on right side */}
+      {!prefersReducedMotion && (
       <div className="absolute right-4 md:right-12 top-1/4 hidden sm:block">
         {[...Array(8)].map((_, i) => (
           <motion.div
@@ -240,15 +261,16 @@ export function LandingPage() {
           </motion.div>
         ))}
       </div>
+      )}
 
       {/* Main content — hero */}
       <div className="relative z-10 min-h-screen flex flex-col items-center justify-center px-4 sm:px-8 w-full max-w-full">
         
         {/* Top HUD bar */}
         <motion.div
-          initial={{ y: -50, opacity: 0 }}
+          initial={prefersReducedMotion ? false : { y: -50, opacity: 0 }}
           animate={{ y: 0, opacity: 1 }}
-          transition={{ delay: 0.2 }}
+          transition={reducedMotionTransition(prefersReducedMotion, { delay: 0.2 })}
           className="absolute top-4 md:top-8 left-0 right-0 flex items-center justify-center gap-3 md:gap-8"
         >
           <div className="flex items-center gap-3 md:gap-8">
@@ -256,18 +278,22 @@ export function LandingPage() {
               <motion.div
                 className="w-2 h-2 md:w-3 md:h-3 rounded-full"
                 style={{ backgroundColor: 'var(--color-theme-primary)' }}
-                animate={{
-                  opacity: [0.5, 1, 0.5],
-                  boxShadow: [
-                    `0 0 10px rgba(var(--color-theme-primary-rgb), 0.5)`,
-                    `0 0 20px rgba(var(--color-theme-primary-rgb), 1)`,
-                    `0 0 10px rgba(var(--color-theme-primary-rgb), 0.5)`,
-                  ],
-                }}
-                transition={{
+                animate={
+                  prefersReducedMotion
+                    ? { opacity: 1 }
+                    : {
+                        opacity: [0.5, 1, 0.5],
+                        boxShadow: [
+                          `0 0 10px rgba(var(--color-theme-primary-rgb), 0.5)`,
+                          `0 0 20px rgba(var(--color-theme-primary-rgb), 1)`,
+                          `0 0 10px rgba(var(--color-theme-primary-rgb), 0.5)`,
+                        ],
+                      }
+                }
+                transition={reducedMotionTransition(prefersReducedMotion, {
                   duration: 2,
                   repeat: Infinity,
-                }}
+                })}
               />
               <span className="text-xs md:text-sm font-black tracking-[0.2em] md:tracking-[0.3em] text-white">LIVE</span>
             </div>

--- a/app/components/StoryShell.tsx
+++ b/app/components/StoryShell.tsx
@@ -1,7 +1,14 @@
 "use client";
 
-import { lazy, Suspense } from 'react';
+import { type ReactNode, useEffect } from "react";
+import { motion } from "framer-motion";
 import { Home, Share2, ChevronRight, Palette } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { MuteToggle } from "./MuteToggle";
+import {
+  useReducedMotion,
+  reducedMotionTransition,
+} from "@/app/hooks/useReducedMotion";
 
 interface StoryShellProps {
   children: ReactNode;
@@ -20,6 +27,7 @@ const SEGMENT_LABELS = [
 
 export function StoryShell({ children, activeSegment = 1 }: StoryShellProps) {
   const router = useRouter();
+  const prefersReducedMotion = useReducedMotion();
   const segmentLabel =
     SEGMENT_LABELS[activeSegment] ?? `Story segment ${activeSegment + 1}`;
 
@@ -33,20 +41,21 @@ export function StoryShell({ children, activeSegment = 1 }: StoryShellProps) {
         heading.setAttribute("tabindex", "-1");
       }
       heading.focus({ preventScroll: true });
-    }, 100);
+    }, prefersReducedMotion ? 0 : 100);
 
     return () => window.clearTimeout(id);
-  }, [activeSegment]);
+  }, [activeSegment, prefersReducedMotion]);
 
   return (
-    <div className="relative min-h-screen bg-[#0a0a0a] text-white overflow-hidden flex flex-col font-sans" style={{ touchAction: "pan-y" }}>
-      {/* Deep space gradient - like landing page */}
+    <div
+      className="relative min-h-screen bg-[#0a0a0a] text-white overflow-hidden flex flex-col font-sans"
+      style={{ touchAction: "pan-y" }}
+    >
       <div
         className="absolute inset-0 bg-gradient-to-b from-black/20 via-transparent to-black/40"
         aria-hidden="true"
       />
 
-      {/* Hexagonal grid pattern - matching landing page */}
       <div className="absolute inset-0 opacity-[0.08]" aria-hidden="true">
         <svg
           className="w-full h-full"
@@ -72,7 +81,6 @@ export function StoryShell({ children, activeSegment = 1 }: StoryShellProps) {
         </svg>
       </div>
 
-      {/* Animated scan lines */}
       <motion.div
         className="absolute inset-0 pointer-events-none"
         aria-hidden="true"
@@ -80,95 +88,97 @@ export function StoryShell({ children, activeSegment = 1 }: StoryShellProps) {
           backgroundImage:
             "repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(29,185,84,0.02) 2px, rgba(29,185,84,0.02) 4px)",
         }}
-        animate={{
-          backgroundPosition: ["0px 0px", "0px 4px"],
-        }}
-        transition={{
+        animate={
+          prefersReducedMotion
+            ? undefined
+            : { backgroundPosition: ["0px 0px", "0px 4px"] }
+        }
+        transition={reducedMotionTransition(prefersReducedMotion, {
           duration: 0.15,
           repeat: Infinity,
           ease: "linear",
-        }}
+        })}
       />
 
-      {/* Animated glow orbs - like landing page */}
       <motion.div
         className="absolute top-0 left-1/2 -translate-x-1/2 w-[1000px] h-[600px] rounded-full blur-[200px] pointer-events-none"
         aria-hidden="true"
         style={{ backgroundColor: "rgba(29, 185, 84, 0.08)" }}
-        animate={{
-          scale: [1, 1.15, 1],
-          opacity: [0.08, 0.15, 0.08],
-        }}
-        transition={{
+        animate={
+          prefersReducedMotion
+            ? { opacity: 0.1, scale: 1 }
+            : {
+                scale: [1, 1.15, 1],
+                opacity: [0.08, 0.15, 0.08],
+              }
+        }
+        transition={reducedMotionTransition(prefersReducedMotion, {
           duration: 8,
           repeat: Infinity,
           ease: "easeInOut",
-        }}
+        })}
       />
 
       <motion.div
         className="absolute bottom-0 left-1/4 w-[600px] h-[400px] rounded-full blur-[150px] pointer-events-none"
         aria-hidden="true"
         style={{ backgroundColor: "rgba(29, 185, 84, 0.06)" }}
-        animate={{
-          scale: [1, 1.2, 1],
-          opacity: [0.06, 0.12, 0.06],
-        }}
-        transition={{
+        animate={
+          prefersReducedMotion
+            ? { opacity: 0.08, scale: 1 }
+            : {
+                scale: [1, 1.2, 1],
+                opacity: [0.06, 0.12, 0.06],
+              }
+        }
+        transition={reducedMotionTransition(prefersReducedMotion, {
           duration: 10,
           repeat: Infinity,
           ease: "easeInOut",
-        }}
+        })}
       />
 
-      {/* Top Controls */}
       <div className="relative z-50 flex justify-between items-center px-3 sm:px-6 md:px-8 lg:px-12 py-4 sm:py-6 md:py-8 overflow-x-auto">
-        {/* Home Button */}
         <motion.button
-          initial={{ opacity: 0, x: -20 }}
+          type="button"
+          initial={prefersReducedMotion ? false : { opacity: 0, x: -20 }}
           animate={{ opacity: 1, x: 0 }}
-          transition={{ delay: 0.2 }}
+          transition={reducedMotionTransition(prefersReducedMotion, {
+            delay: 0.2,
+          })}
           onClick={() => router.push("/")}
+          className="group flex items-center gap-2 text-sm font-medium text-white/80"
+          aria-label="Go home"
         >
           <Home
             className="w-4 h-4 group-hover:scale-110 transition-transform"
             aria-hidden="true"
           />
           <span>Home</span>
-          <AnimatePresence mode="wait">
-            {cards.map((card, index) => (
-              <motion.div 
-                key={card.id}
-                initial={{ opacity: 0, x: 100 }}
-                animate={{ opacity: 1, x: 0 }}
-                exit={{ opacity: 0, x: -100 }}
-                className="absolute inset-0"
-              >
-                <LazyStoryCard>
-                  <Suspense fallback={<StorySkeleton />}>
-                    {/* Render your specific lazy component based on the flow */}
-                    {index === 0 && <TopDapps />}
-                    {index === 1 && <TransactionsOfFury />}
-                  </Suspense>
-                </LazyStoryCard>
-              </motion.div>
-            ))}
-        </AnimatePresence>
         </motion.button>
 
-        {/* Segmented Progress Bar */}
         <motion.div
-          initial={{ opacity: 0, y: -10 }}
+          initial={prefersReducedMotion ? false : { opacity: 0, y: -10 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.3 }}
+          transition={reducedMotionTransition(prefersReducedMotion, {
+            delay: 0.3,
+          })}
+          className="flex items-center gap-1.5"
+          role="progressbar"
+          aria-valuenow={activeSegment + 1}
+          aria-valuemin={1}
+          aria-valuemax={SEGMENT_LABELS.length}
+          aria-label={segmentLabel}
         >
           {[...Array(7)].map((_, i) => (
             <motion.div
               key={i}
               aria-hidden="true"
-              initial={{ scaleX: 0 }}
+              initial={prefersReducedMotion ? false : { scaleX: 0 }}
               animate={{ scaleX: 1 }}
-              transition={{ delay: 0.4 + i * 0.05 }}
+              transition={reducedMotionTransition(prefersReducedMotion, {
+                delay: 0.4 + i * 0.05,
+              })}
               className={`h-1.5 rounded-full transition-all duration-500 ${
                 i === activeSegment
                   ? "w-10 bg-[#1DB954] shadow-[0_0_12px_rgba(29,185,84,0.8)]"
@@ -180,27 +190,23 @@ export function StoryShell({ children, activeSegment = 1 }: StoryShellProps) {
           ))}
         </motion.div>
 
-
         <div className="flex items-center gap-2 shrink-0">
-
-            <MuteToggle />
-          {/* Palette Button */}
+          <MuteToggle />
           <motion.button
             type="button"
-            initial={{ opacity: 0, x: 20 }}
+            initial={prefersReducedMotion ? false : { opacity: 0, x: 20 }}
             animate={{ opacity: 1, x: 0 }}
-            transition={{ delay: 0.35 }}
+            transition={reducedMotionTransition(prefersReducedMotion, {
+              delay: 0.35,
+            })}
             className="p-3 rounded-full bg-black/50 border border-[#1DB954]/30 backdrop-blur-xl hover:bg-[#1DB954]/10 hover:border-[#1DB954]/50 transition-all shadow-[0_0_20px_rgba(29,185,84,0.15)]"
             aria-label="Open color theme picker"
           >
             <Palette className="w-5 h-5 text-[#1DB954]" aria-hidden="true" />
           </motion.button>
         </div>
-
-
       </div>
 
-      {/* Main Content */}
       <div className="sr-only" aria-live="polite" aria-atomic="true">
         {segmentLabel}
       </div>
@@ -209,20 +215,26 @@ export function StoryShell({ children, activeSegment = 1 }: StoryShellProps) {
         {children}
       </div>
 
-      {/* Bottom Controls */}
       <div className="relative z-50 flex justify-between items-center px-3 sm:px-6 md:px-8 lg:px-12 py-4 sm:py-6 md:py-8 gap-4">
         <motion.button
-          initial={{ opacity: 0, y: 20 }}
+          type="button"
+          initial={prefersReducedMotion ? false : { opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.5 }}
+          transition={reducedMotionTransition(prefersReducedMotion, {
+            delay: 0.5,
+          })}
+          aria-label="Share"
         >
           <Share2 className="w-5 h-5 text-white/70" aria-hidden="true" />
         </motion.button>
         <motion.button
           type="button"
-          initial={{ opacity: 0, y: 20 }}
+          initial={prefersReducedMotion ? false : { opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.5 }}
+          transition={reducedMotionTransition(prefersReducedMotion, {
+            delay: 0.5,
+          })}
+          aria-label="Next"
         >
           <ChevronRight
             className="w-6 h-6 group-hover:translate-x-1 transition-transform text-white/70"

--- a/app/components/ZeroActivityEmptyState.tsx
+++ b/app/components/ZeroActivityEmptyState.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Inbox, RefreshCw, Globe2, CalendarRange } from "lucide-react";
+import { useWrapStore, type WrapPeriod } from "@/app/store/wrapStore";
+
+interface ZeroActivityEmptyStateProps {
+  /** Optional override for the selected period label */
+  periodLabel?: string;
+  className?: string;
+}
+
+const PERIOD_LABELS: Record<WrapPeriod, string> = {
+  weekly: "past week",
+  monthly: "past month",
+  yearly: "past year",
+};
+
+export function ZeroActivityEmptyState({
+  periodLabel,
+  className = "",
+}: ZeroActivityEmptyStateProps) {
+  const router = useRouter();
+  const { period, network, setPeriod, setNetwork, setResult, setStatus, reset } =
+    useWrapStore();
+
+  const label = periodLabel ?? PERIOD_LABELS[period] ?? "selected period";
+  const otherNetwork = network === "mainnet" ? "testnet" : "mainnet";
+  const nextPeriod: WrapPeriod =
+    period === "weekly" ? "monthly" : period === "monthly" ? "yearly" : "weekly";
+
+  const startFresh = (navigateTo: string) => {
+    setResult(null);
+    setStatus("idle");
+    router.push(navigateTo);
+  };
+
+  return (
+    <div
+      className={`relative z-20 flex flex-col items-center justify-center text-center px-6 py-12 max-w-lg mx-auto ${className}`}
+      data-testid="zero-activity-empty-state"
+      role="status"
+      aria-live="polite"
+    >
+      <div
+        className="mb-6 flex h-16 w-16 items-center justify-center rounded-2xl border border-white/15 bg-black/40"
+        aria-hidden="true"
+      >
+        <Inbox className="h-8 w-8 text-white/70" />
+      </div>
+
+      <h2 className="text-2xl sm:text-3xl font-black text-white tracking-tight mb-3">
+        No activity in this period
+      </h2>
+      <p className="text-sm sm:text-base text-white/60 mb-8 leading-relaxed">
+        This account is valid, but we found zero transactions for the {label} on{" "}
+        <span className="text-white/80 font-semibold">{network}</span>. Try a
+        wider window or switch networks — no mock stats here.
+      </p>
+
+      <div className="flex flex-col sm:flex-row flex-wrap items-stretch justify-center gap-3 w-full">
+        <button
+          type="button"
+          onClick={() => {
+            setPeriod(nextPeriod);
+            startFresh("/loading");
+          }}
+          className="inline-flex items-center justify-center gap-2 rounded-xl border border-white/20 bg-white/5 px-4 py-3 text-sm font-semibold text-white hover:bg-white/10 transition-colors"
+        >
+          <CalendarRange className="h-4 w-4" aria-hidden="true" />
+          Try {PERIOD_LABELS[nextPeriod]}
+        </button>
+
+        <button
+          type="button"
+          onClick={() => {
+            setNetwork(otherNetwork);
+            startFresh("/loading");
+          }}
+          className="inline-flex items-center justify-center gap-2 rounded-xl border border-white/20 bg-white/5 px-4 py-3 text-sm font-semibold text-white hover:bg-white/10 transition-colors"
+        >
+          <Globe2 className="h-4 w-4" aria-hidden="true" />
+          Switch to {otherNetwork}
+        </button>
+
+        <button
+          type="button"
+          onClick={() => {
+            reset();
+            router.push("/connect");
+          }}
+          className="inline-flex items-center justify-center gap-2 rounded-xl border border-[var(--color-theme-primary)]/40 bg-[var(--color-theme-primary)]/15 px-4 py-3 text-sm font-semibold text-white hover:bg-[var(--color-theme-primary)]/25 transition-colors"
+        >
+          <RefreshCw className="h-4 w-4" aria-hidden="true" />
+          Change wallet
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/hooks/__tests__/useReducedMotion.test.ts
+++ b/app/hooks/__tests__/useReducedMotion.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  getPrefersReducedMotion,
+  REDUCED_MOTION_QUERY,
+  reducedMotionTransition,
+} from "@/app/hooks/useReducedMotion";
+
+describe("reduced motion utilities", () => {
+  it("exposes the standard media query", () => {
+    expect(REDUCED_MOTION_QUERY).toBe("(prefers-reduced-motion: reduce)");
+  });
+
+  it("reads matches from a provided MediaQueryList", () => {
+    expect(getPrefersReducedMotion({ matches: true })).toBe(true);
+    expect(getPrefersReducedMotion({ matches: false })).toBe(false);
+  });
+
+  it("returns false when window is unavailable (SSR-safe)", () => {
+    expect(getPrefersReducedMotion(null)).toBe(false);
+  });
+
+  it("collapses decorative transitions when reduced motion is enabled", () => {
+    expect(
+      reducedMotionTransition(true, {
+        duration: 2,
+        delay: 0.5,
+        repeat: Infinity,
+      }),
+    ).toEqual({
+      duration: 0,
+      delay: 0,
+      repeat: 0,
+    });
+  });
+
+  it("preserves transitions when reduced motion is disabled", () => {
+    const transition = { duration: 2, repeat: Infinity };
+    expect(reducedMotionTransition(false, transition)).toEqual(transition);
+  });
+});

--- a/app/hooks/useReducedMotion.ts
+++ b/app/hooks/useReducedMotion.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+/**
+ * Pure check for prefers-reduced-motion (safe for SSR — returns false when window is unavailable).
+ */
+export function getPrefersReducedMotion(
+  mediaQueryList?: Pick<MediaQueryList, "matches"> | null,
+): boolean {
+  if (mediaQueryList) {
+    return mediaQueryList.matches;
+  }
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return false;
+  }
+  return window.matchMedia(REDUCED_MOTION_QUERY).matches;
+}
+
+/**
+ * React hook that tracks `prefers-reduced-motion` and updates on change.
+ * Use to disable or simplify non-essential continuous animations while
+ * keeping progress/state changes visible.
+ */
+export function useReducedMotion(): boolean {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(REDUCED_MOTION_QUERY);
+    const update = () => setPrefersReducedMotion(mediaQuery.matches);
+
+    update();
+
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", update);
+      return () => mediaQuery.removeEventListener("change", update);
+    }
+
+    mediaQuery.addListener(update);
+    return () => mediaQuery.removeListener(update);
+  }, []);
+
+  return prefersReducedMotion;
+}
+
+/**
+ * Returns a Framer Motion transition that is instant when reduced motion is on.
+ * Core state/progress updates remain visible without decorative looping motion.
+ */
+export function reducedMotionTransition(
+  prefersReducedMotion: boolean,
+  transition: Record<string, unknown> = {},
+): Record<string, unknown> {
+  if (prefersReducedMotion) {
+    return { ...transition, duration: 0, delay: 0, repeat: 0 };
+  }
+  return transition;
+}

--- a/app/loading/page.tsx
+++ b/app/loading/page.tsx
@@ -12,16 +12,24 @@ import { MuteToggle } from "../components/MuteToggle";
 import { useWrapStore, type WrapResult } from "../store/wrapStore";
 
 import { useSound } from "../hooks/useSound";
+import { useReducedMotion, reducedMotionTransition } from "../hooks/useReducedMotion";
 import { SOUND_NAMES } from "../utils/soundManager";
 import { indexAccount } from "../services/indexerService";
 import { IndexerEventEmitter } from "../utils/indexerEventEmitter";
+import { isZeroActivityResult } from "../utils/zeroActivity";
+import { ZeroActivityEmptyState } from "../components/ZeroActivityEmptyState";
 
 export default function LoadingScreen() {
   const router = useRouter();
-  const { address, period, network, setStatus, setResult, setError, setCacheMeta, startIndexing, cancelIndexing, completeIndexing, syncIndexingProgress } =
+  const prefersReducedMotion = useReducedMotion();
+  const { address, period, network, status, result, setStatus, setResult, setError, setCacheMeta, startIndexing, cancelIndexing, completeIndexing, syncIndexingProgress } =
     useWrapStore();
 
   const { playSound } = useSound();
+  const showZeroActivity =
+    Boolean(address) &&
+    status === "ready" &&
+    isZeroActivityResult(result);
 
   const handleComplete = useCallback(() => {
     playSound(SOUND_NAMES.SLIDE_WHOOSH);
@@ -48,7 +56,7 @@ export default function LoadingScreen() {
       syncIndexingProgress();
 
       const state = useWrapStore.getState();
-      if (state.status === "ready") {
+      if (state.status === "ready" && !isZeroActivityResult(state.result)) {
         handleComplete();
       }
     };
@@ -172,6 +180,11 @@ export default function LoadingScreen() {
         playSound(SOUND_NAMES.MINT_SUCCESS);
         trackEvent("wrap_completed");
 
+        // Honest empty state for valid accounts with no period activity
+        if (address && isZeroActivityResult(result)) {
+          return;
+        }
+
         // Give progress display time to be visible (minimum 1.5 seconds)
         setTimeout(() => {
           if (isMounted) {
@@ -234,7 +247,12 @@ export default function LoadingScreen() {
     <div className="relative w-full min-h-screen h-screen overflow-hidden flex items-center justify-center bg-theme-background">
       <ProgressIndicator currentStep={3} totalSteps={6} showNext={false} />
 
-      {/* Container for centered layout with progress left and content right */}
+      {showZeroActivity ? (
+        <div className="relative z-40 w-full max-w-2xl px-4">
+          <ZeroActivityEmptyState />
+        </div>
+      ) : (
+      /* Container for centered layout with progress left and content right */
       <div className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-40 w-full max-w-6xl px-4 pointer-events-auto">
         <div className="flex items-center justify-between gap-8">
           {/* StepProgressDisplay - Real-time indexing step progress with labels */}
@@ -249,6 +267,7 @@ export default function LoadingScreen() {
           {/* Content area - Right side will be filled by the main content below */}
         </div>
       </div>
+      )}
 
       <div className="absolute inset-0 from-black via-black to-black opacity-60" />
 
@@ -262,11 +281,11 @@ export default function LoadingScreen() {
         }}
         className="absolute top-6 left-6 md:top-8 md:left-8 z-30 group"
         aria-label="Go to home page"
-        initial={{ opacity: 0, x: -20 }}
+        initial={prefersReducedMotion ? false : { opacity: 0, x: -20 }}
         animate={{ opacity: 1, x: 0 }}
-        transition={{ delay: 0.2 }}
-        whileHover={{ scale: 1.05 }}
-        whileTap={{ scale: 0.95 }}
+        transition={reducedMotionTransition(prefersReducedMotion, { delay: 0.2 })}
+        whileHover={prefersReducedMotion ? undefined : { scale: 1.05 }}
+        whileTap={prefersReducedMotion ? undefined : { scale: 0.95 }}
         aria-label="Go home"
       >
         <div
@@ -285,13 +304,14 @@ export default function LoadingScreen() {
 
       <motion.div
         className="absolute top-6 right-6 md:top-8 md:right-8 z-30"
-        initial={{ opacity: 0, x: 20 }}
+        initial={prefersReducedMotion ? false : { opacity: 0, x: 20 }}
         animate={{ opacity: 1, x: 0 }}
-        transition={{ delay: 0.2 }}
+        transition={reducedMotionTransition(prefersReducedMotion, { delay: 0.2 })}
       >
         <MuteToggle />
       </motion.div>
 
+      {!showZeroActivity && (
       <motion.button
         onClick={() => {
           playSound(SOUND_NAMES.SLIDE_WHOOSH);
@@ -306,11 +326,11 @@ export default function LoadingScreen() {
         }}
         className="absolute bottom-8 right-8 md:bottom-12 md:right-12 z-30 group"
         aria-label="Skip loading and go to persona step"
-        initial={{ opacity: 0, scale: 0.8 }}
+        initial={prefersReducedMotion ? false : { opacity: 0, scale: 0.8 }}
         animate={{ opacity: 1, scale: 1 }}
-        transition={{ delay: 1 }}
-        whileHover={{ scale: 1.1 }}
-        whileTap={{ scale: 0.95 }}
+        transition={reducedMotionTransition(prefersReducedMotion, { delay: 1 })}
+        whileHover={prefersReducedMotion ? undefined : { scale: 1.1 }}
+        whileTap={prefersReducedMotion ? undefined : { scale: 0.95 }}
         aria-label="Skip"
       >
         <div className="flex flex-col items-center gap-2">
@@ -318,13 +338,15 @@ export default function LoadingScreen() {
             <motion.div
               className="absolute -inset-2 rounded-full blur-lg"
               style={{ backgroundColor: "rgba(0, 0, 0, 0.4)" }}
-              animate={{
-                opacity: [0.4, 0.7, 0.4],
-              }}
-              transition={{
+              animate={
+                prefersReducedMotion
+                  ? { opacity: 0.5 }
+                  : { opacity: [0.4, 0.7, 0.4] }
+              }
+              transition={reducedMotionTransition(prefersReducedMotion, {
                 duration: 2,
                 repeat: Infinity,
-              }}
+              })}
             />
             <div
               className="relative w-14 h-14 md:w-16 md:h-16 rounded-full flex items-center justify-center border-2 transition-all"
@@ -344,6 +366,7 @@ export default function LoadingScreen() {
           </span>
         </div>
       </motion.button>
+      )}
 
       <div className="absolute inset-0 opacity-20">
         <motion.div
@@ -353,18 +376,21 @@ export default function LoadingScreen() {
                              linear-gradient(90deg, rgba(var(--color-theme-primary-rgb), 0.3) 1px, transparent 1px)`,
             backgroundSize: "100px 100px",
           }}
-          animate={{
-            backgroundPosition: ["0px 0px", "100px 100px"],
-          }}
-          transition={{
+          animate={
+            prefersReducedMotion
+              ? undefined
+              : { backgroundPosition: ["0px 0px", "100px 100px"] }
+          }
+          transition={reducedMotionTransition(prefersReducedMotion, {
             duration: 3,
             repeat: Infinity,
             ease: "linear",
-          }}
+          })}
         />
       </div>
 
-      {starConfigs.map((cfg, i) => (
+      {!prefersReducedMotion &&
+        starConfigs.map((cfg, i) => (
         <motion.div
           key={i}
           className="absolute w-1 h-1 rounded-full"
@@ -389,35 +415,44 @@ export default function LoadingScreen() {
       <motion.div
         className="absolute w-96 h-96 rounded-full blur-[120px]"
         style={{ backgroundColor: "rgba(var(--color-theme-primary-rgb), 0.3)" }}
-        animate={{
-          scale: [1, 1.3, 1],
-          opacity: [0.3, 0.5, 0.3],
-          x: [-50, 50, -50],
-          y: [-50, 50, -50],
-        }}
-        transition={{
+        animate={
+          prefersReducedMotion
+            ? { opacity: 0.35, scale: 1 }
+            : {
+                scale: [1, 1.3, 1],
+                opacity: [0.3, 0.5, 0.3],
+                x: [-50, 50, -50],
+                y: [-50, 50, -50],
+              }
+        }
+        transition={reducedMotionTransition(prefersReducedMotion, {
           duration: 5,
           repeat: Infinity,
           ease: "easeInOut",
-        }}
+        })}
       />
 
       <motion.div
         className="absolute w-80 h-80 rounded-full blur-[100px]"
         style={{ backgroundColor: "rgba(var(--color-theme-primary-rgb), 0.2)" }}
-        animate={{
-          scale: [1, 1.2, 1],
-          opacity: [0.2, 0.4, 0.2],
-          x: [50, -50, 50],
-          y: [50, -50, 50],
-        }}
-        transition={{
+        animate={
+          prefersReducedMotion
+            ? { opacity: 0.25, scale: 1 }
+            : {
+                scale: [1, 1.2, 1],
+                opacity: [0.2, 0.4, 0.2],
+                x: [50, -50, 50],
+                y: [50, -50, 50],
+              }
+        }
+        transition={reducedMotionTransition(prefersReducedMotion, {
           duration: 4,
           repeat: Infinity,
           ease: "easeInOut",
-        }}
+        })}
       />
 
+      {!showZeroActivity && (
       <div className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-10 px-4 w-full max-w-6xl">
         <div className="flex items-center justify-between gap-8">
           {/* Left side: reserved for progress (empty here, filled by overlay) */}
@@ -426,39 +461,51 @@ export default function LoadingScreen() {
           {/* Right side: WRAPPING YOUR JOURNEY content */}
           <div className="flex-1">
             <motion.div
-              initial={{ opacity: 0, y: 30 }}
+              initial={prefersReducedMotion ? false : { opacity: 0, y: 30 }}
               animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.3, type: "spring", stiffness: 100 }}
+              transition={reducedMotionTransition(prefersReducedMotion, {
+                delay: 0.3,
+                type: "spring",
+                stiffness: 100,
+              })}
             >
               <motion.h1
                 className="text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-black text-white mb-4 md:mb-6 tracking-tighter leading-none"
-                animate={{
-                  textShadow: [
-                    `0 0 20px rgba(var(--color-theme-primary-rgb), 0.5)`,
-                    `0 0 40px rgba(var(--color-theme-primary-rgb), 0.8)`,
-                    `0 0 20px rgba(var(--color-theme-primary-rgb), 0.5)`,
-                  ],
-                }}
-                transition={{
+                animate={
+                  prefersReducedMotion
+                    ? undefined
+                    : {
+                        textShadow: [
+                          `0 0 20px rgba(var(--color-theme-primary-rgb), 0.5)`,
+                          `0 0 40px rgba(var(--color-theme-primary-rgb), 0.8)`,
+                          `0 0 20px rgba(var(--color-theme-primary-rgb), 0.5)`,
+                        ],
+                      }
+                }
+                transition={reducedMotionTransition(prefersReducedMotion, {
                   duration: 2,
                   repeat: Infinity,
-                }}
+                })}
               >
                 WRAPPING
               </motion.h1>
               <motion.h2
                 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-black text-white/80 mb-6 md:mb-10 tracking-tight leading-none"
-                initial={{ opacity: 0 }}
+                initial={prefersReducedMotion ? false : { opacity: 0 }}
                 animate={{ opacity: 1 }}
-                transition={{ delay: 0.6 }}
+                transition={reducedMotionTransition(prefersReducedMotion, {
+                  delay: 0.6,
+                })}
               >
                 YOUR JOURNEY
               </motion.h2>
 
               <motion.div
-                initial={{ opacity: 0, scale: 0.9 }}
+                initial={prefersReducedMotion ? false : { opacity: 0, scale: 0.9 }}
                 animate={{ opacity: 1, scale: 1 }}
-                transition={{ delay: 0.9 }}
+                transition={reducedMotionTransition(prefersReducedMotion, {
+                  delay: 0.9,
+                })}
                 className="inline-block"
               >
                 <div className="relative">
@@ -468,13 +515,15 @@ export default function LoadingScreen() {
                       backgroundColor:
                         "rgba(var(--color-theme-primary-rgb), 0.4)",
                     }}
-                    animate={{
-                      opacity: [0.5, 0.8, 0.5],
-                    }}
-                    transition={{
+                    animate={
+                      prefersReducedMotion
+                        ? { opacity: 0.6 }
+                        : { opacity: [0.5, 0.8, 0.5] }
+                    }
+                    transition={reducedMotionTransition(prefersReducedMotion, {
                       duration: 2,
                       repeat: Infinity,
-                    }}
+                    })}
                   />
                   <div
                     className="relative backdrop-blur-sm px-6 py-3 sm:px-8 sm:py-4 md:px-12 md:py-6 rounded-xl md:rounded-2xl"
@@ -501,21 +550,33 @@ export default function LoadingScreen() {
 
             <motion.div
               className="mt-12 md:mt-16 w-48 sm:w-56 md:w-64 h-1 bg-white/10 rounded-full mx-auto overflow-hidden"
-              initial={{ opacity: 0 }}
+              initial={prefersReducedMotion ? false : { opacity: 0 }}
               animate={{ opacity: 1 }}
-              transition={{ delay: 1.2 }}
+              transition={reducedMotionTransition(prefersReducedMotion, {
+                delay: 1.2,
+              })}
+              aria-hidden={false}
+              role="progressbar"
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label="Loading progress"
             >
               <motion.div
                 className="h-full"
                 style={{ backgroundColor: "var(--color-theme-primary)" }}
                 initial={{ width: "0%" }}
                 animate={{ width: "100%" }}
-                transition={{ duration: 2.5, ease: "easeInOut" }}
+                transition={
+                  prefersReducedMotion
+                    ? { duration: 0.01 }
+                    : { duration: 2.5, ease: "easeInOut" }
+                }
               />
             </motion.div>
           </div>
         </div>
       </div>
+      )}
     </div>
   );
 }

--- a/app/utils/__tests__/indexerEventEmitter.test.ts
+++ b/app/utils/__tests__/indexerEventEmitter.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const setCurrentStep = vi.fn();
+const setStepProgress = vi.fn();
+const completeStep = vi.fn();
+const setIndexingError = vi.fn();
+const clearPersistedIndexingState = vi.fn();
+const cancelIndexing = vi.fn();
+
+vi.mock("@/app/store/wrapStore", () => ({
+  useWrapStore: {
+    getState: () => ({
+      setCurrentStep,
+      setStepProgress,
+      completeStep,
+      setIndexingError,
+      clearPersistedIndexingState,
+      cancelIndexing,
+    }),
+  },
+}));
+
+describe("IndexerEventEmitter singleton lifecycle", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    const { IndexerEventEmitter } = await import(
+      "@/app/utils/indexerEventEmitter"
+    );
+    IndexerEventEmitter.getInstance().reset();
+  });
+
+  it("connect → reset → connect registers listeners only once per session", async () => {
+    const { IndexerEventEmitter } = await import(
+      "@/app/utils/indexerEventEmitter"
+    );
+    const emitter = IndexerEventEmitter.getInstance();
+
+    emitter.connectToStore();
+    emitter.connectToStore(); // duplicate call must be a no-op
+    expect(emitter.listenerCount("step-change")).toBe(1);
+
+    emitter.emitStepChange("initializing");
+    expect(setCurrentStep).toHaveBeenCalledTimes(1);
+    expect(setCurrentStep).toHaveBeenCalledWith("initializing");
+
+    emitter.reset();
+    expect(emitter.listenerCount("step-change")).toBe(0);
+
+    // Stale session: events after reset must not update the store
+    emitter.emitStepChange("fetching-transactions");
+    expect(setCurrentStep).toHaveBeenCalledTimes(1);
+
+    emitter.connectToStore();
+    expect(emitter.listenerCount("step-change")).toBe(1);
+
+    emitter.emitStepChange("finalizing");
+    expect(setCurrentStep).toHaveBeenCalledTimes(2);
+    expect(setCurrentStep).toHaveBeenLastCalledWith("finalizing");
+  });
+
+  it("emits exactly one store update per indexing event after reconnect", async () => {
+    const { IndexerEventEmitter } = await import(
+      "@/app/utils/indexerEventEmitter"
+    );
+    const emitter = IndexerEventEmitter.getInstance();
+
+    emitter.connectToStore();
+    emitter.reset();
+    emitter.connectToStore();
+
+    emitter.emitStepProgress("calculating-volume", 40);
+    emitter.emitStepComplete("calculating-volume");
+
+    expect(setStepProgress).toHaveBeenCalledTimes(1);
+    expect(setStepProgress).toHaveBeenCalledWith("calculating-volume", 40);
+    expect(completeStep).toHaveBeenCalledTimes(1);
+    expect(completeStep).toHaveBeenCalledWith("calculating-volume");
+  });
+
+  it("disconnectFromStore clears listeners the same way as reset", async () => {
+    const { IndexerEventEmitter } = await import(
+      "@/app/utils/indexerEventEmitter"
+    );
+    const emitter = IndexerEventEmitter.getInstance();
+
+    emitter.connectToStore();
+    emitter.disconnectFromStore();
+    expect(emitter.listenerCount("step-progress")).toBe(0);
+
+    emitter.connectToStore();
+    emitter.emitStepProgress("identifying-assets", 10);
+    expect(setStepProgress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/utils/__tests__/zeroActivity.test.ts
+++ b/app/utils/__tests__/zeroActivity.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { isZeroActivityResult } from "@/app/utils/zeroActivity";
+import { mapIndexerResultToWrapResult } from "@/app/utils/wrapResultMapper";
+import type { IndexerResult } from "@/app/utils/indexer";
+import { getStellarExpertAccountUrl } from "@/app/utils/stellarExpert";
+
+function emptyIndexerResult(
+  overrides: Partial<IndexerResult> = {},
+): IndexerResult {
+  return {
+    accountId: "GABCDEF123456789",
+    totalTransactions: 0,
+    totalVolume: 0,
+    mostActiveAsset: "XLM",
+    contractCalls: 0,
+    gasSpent: 0,
+    dapps: [],
+    vibes: [],
+    ...overrides,
+  };
+}
+
+describe("zero-activity detection and mapping", () => {
+  it("detects zero transaction indexer/wrap results", () => {
+    expect(isZeroActivityResult({ totalTransactions: 0 })).toBe(true);
+    expect(isZeroActivityResult({ totalTransactions: 1 })).toBe(false);
+    expect(isZeroActivityResult(null)).toBe(false);
+    expect(isZeroActivityResult(undefined)).toBe(false);
+  });
+
+  it("maps zero-activity indexer results without falling back to mock stats", () => {
+    const wrap = mapIndexerResultToWrapResult(emptyIndexerResult());
+
+    expect(wrap.totalTransactions).toBe(0);
+    expect(wrap.dapps).toEqual([]);
+    expect(wrap.vibes).toEqual([]);
+    expect(wrap.percentile).toBe(0);
+    expect(isZeroActivityResult(wrap)).toBe(true);
+  });
+
+  it("still maps non-zero results with real transaction counts", () => {
+    const wrap = mapIndexerResultToWrapResult(
+      emptyIndexerResult({
+        totalTransactions: 12,
+        dapps: [
+          {
+            name: "Mercurius",
+            transactionCount: 5,
+            volume: 100,
+          },
+        ],
+      }),
+    );
+
+    expect(wrap.totalTransactions).toBe(12);
+    expect(wrap.dapps[0]?.name).toBe("Mercurius");
+    expect(isZeroActivityResult(wrap)).toBe(false);
+  });
+
+  it("documents the empty-state UI test id used for zero-tx rendering", () => {
+    // ZeroActivityEmptyState renders data-testid="zero-activity-empty-state"
+    // when isZeroActivityResult(result) is true on loading/persona/share.
+    const wrap = mapIndexerResultToWrapResult(emptyIndexerResult());
+    expect(isZeroActivityResult(wrap)).toBe(true);
+    expect("zero-activity-empty-state").toMatch(/zero-activity/);
+  });
+});
+
+describe("stellar.expert account URL", () => {
+  it("builds network-aware URLs and hides when address is missing", () => {
+    expect(getStellarExpertAccountUrl(null, "mainnet")).toBeNull();
+    expect(getStellarExpertAccountUrl("", "testnet")).toBeNull();
+    expect(getStellarExpertAccountUrl("GABC", "mainnet")).toBe(
+      "https://stellar.expert/explorer/public/account/GABC",
+    );
+    expect(getStellarExpertAccountUrl("GABC", "testnet")).toBe(
+      "https://stellar.expert/explorer/testnet/account/GABC",
+    );
+  });
+});

--- a/app/utils/indexerEventEmitter.ts
+++ b/app/utils/indexerEventEmitter.ts
@@ -96,10 +96,11 @@ export class IndexerEventEmitter extends EventEmitter {
 
   /**
    * Connect emitter to Zustand store (call once during app initialization)
-   * Safe to call multiple times - will only connect once
+   * Safe to call multiple times - will only connect once per session.
+   * Call {@link reset} between loading sessions so listeners are not duplicated.
    */
   connectToStore(): void {
-    // Prevent duplicate listener registration
+    // Prevent duplicate listener registration across repeated sessions
     if (this.isConnected) {
       return;
     }
@@ -122,7 +123,7 @@ export class IndexerEventEmitter extends EventEmitter {
       store.getState().setIndexingError(step, message, recoverable);
     });
 
-    this.on("indexing-complete", ({ _data }) => {
+    this.on("indexing-complete", () => {
       store.getState().clearPersistedIndexingState();
     });
 
@@ -134,6 +135,13 @@ export class IndexerEventEmitter extends EventEmitter {
   }
 
   /**
+   * Whether store listeners are currently attached.
+   */
+  isStoreConnected(): boolean {
+    return this.isConnected;
+  }
+
+  /**
    * Disconnect store listeners (cleanup)
    */
   disconnectFromStore(): void {
@@ -142,7 +150,8 @@ export class IndexerEventEmitter extends EventEmitter {
   }
 
   /**
-   * Remove all listeners and reset connection (cleanup)
+   * Remove all listeners and reset connection so the next session can
+   * safely call {@link connectToStore} without duplicate store updates.
    */
   reset(): void {
     this.removeAllListeners();

--- a/app/utils/stellarExpert.ts
+++ b/app/utils/stellarExpert.ts
@@ -1,0 +1,17 @@
+import type { Network } from "@/src/config";
+
+/**
+ * Build a network-aware Stellar.expert account explorer URL.
+ * Returns null when address is missing.
+ */
+export function getStellarExpertAccountUrl(
+  address: string | null | undefined,
+  network: Network | "mainnet" | "testnet",
+): string | null {
+  if (!address) {
+    return null;
+  }
+
+  const explorerNetwork = network === "testnet" ? "testnet" : "public";
+  return `https://stellar.expert/explorer/${explorerNetwork}/account/${address}`;
+}

--- a/app/utils/wrapResultMapper.ts
+++ b/app/utils/wrapResultMapper.ts
@@ -21,19 +21,25 @@ function mapMockDapps() {
 export function mapIndexerResultToWrapResult(
   indexerResult: IndexerResult,
 ): WrapResult {
+  const isZeroActivity = indexerResult.totalTransactions === 0;
   // Prefer the computed persona from the indexer; fall back to mockData only if absent.
-  const persona = indexerResult.persona ?? mockData.persona;
+  const persona = indexerResult.persona ?? (isZeroActivity ? "Quiet Wallet" : mockData.persona);
 
   return {
     username: mockData.username,
-    totalTransactions: indexerResult.totalTransactions || mockData.transactions,
-    percentile: mockData.percentile,
-    dapps: indexerResult.dapps?.length
-      ? mapIndexerDapps(indexerResult.dapps)
-      : mapMockDapps(),
-    vibes: mockData.vibes,
+    // Preserve legitimate zeros — do not coerce to mock transaction counts.
+    totalTransactions: indexerResult.totalTransactions ?? 0,
+    percentile: isZeroActivity ? 0 : mockData.percentile,
+    dapps: isZeroActivity
+      ? []
+      : indexerResult.dapps?.length
+        ? mapIndexerDapps(indexerResult.dapps)
+        : mapMockDapps(),
+    vibes: isZeroActivity ? [] : mockData.vibes,
     persona,
-    personaDescription: mockData.personaDescription,
+    personaDescription: isZeroActivity
+      ? "No on-chain activity showed up for this period. Try a wider window or another network."
+      : mockData.personaDescription,
     portfolioDiversitySummary: indexerResult.portfolioDiversitySummary,
     biggestDaySummary: indexerResult.biggestDaySummary,
     dexTradingSummary: indexerResult.dexTradingSummary,

--- a/app/utils/zeroActivity.ts
+++ b/app/utils/zeroActivity.ts
@@ -1,0 +1,14 @@
+import type { WrapResult } from "@/app/store/wrapStore";
+import type { IndexerResult } from "@/app/utils/indexer";
+
+/**
+ * True when an indexer/wrap result has no activity in the selected period.
+ */
+export function isZeroActivityResult(
+  result: Pick<WrapResult, "totalTransactions"> | Pick<IndexerResult, "totalTransactions"> | null | undefined,
+): boolean {
+  if (!result) {
+    return false;
+  }
+  return result.totalTransactions === 0;
+}


### PR DESCRIPTION

### PR description

## Summary
- **Indexer emitter:** Hardened singleton `IndexerEventEmitter` connect/reset lifecycle so repeated loading sessions don’t stack store listeners; added connect → reset → connect tests ensuring one store update per indexing event.
- **Reduced motion:** Added `useReducedMotion` / `getPrefersReducedMotion` / `reducedMotionTransition` and wired Landing, Loading, Persona, and StoryShell to disable continuous/decorative motion while keeping progress and state changes visible.
- **Zero activity:** Fixed `mapIndexerResultToWrapResult` so `totalTransactions: 0` no longer falls back to mock stats; added `ZeroActivityEmptyState` with period/network/wallet actions on loading, persona, and share.
- **Explorer link:** Added network-aware Stellar.expert history link on the persona page (shared helper with share); link is hidden when address is missing.

## Details

### Task 1 — IndexerEventEmitter session reset
- Documented and clarified `connectToStore` / `reset` / `disconnectFromStore` for multi-session use.
- Added `isStoreConnected()` and connect/reset/connect coverage in `app/utils/__tests__/indexerEventEmitter.test.ts`.
- Loading page already resets on unmount; zero-activity ready state no longer auto-advances.

### Task 2 — `prefers-reduced-motion`
- New hook/utilities: `app/hooks/useReducedMotion.ts` + tests.
- Decorative loops (particles, scan lines, glows, stars, confetti) are skipped or static when reduced motion is on; progress UI stays.

### Task 3 — Empty state for no recent activity
- Root cause: `totalTransactions || mockData.transactions` treated `0` as falsy.
- Detection via `isZeroActivityResult`; honest empty UI with “try period”, “switch network”, “change wallet”.
- Tests in `app/utils/__tests__/zeroActivity.test.ts`.

### Task 4 — Stellar.expert on persona
- `getStellarExpertAccountUrl(address, network)` in `app/utils/stellarExpert.ts`.
- Persona (and share) use it; link omitted when address is missing.

## Test plan
- [ ] Run indexing twice in one session; confirm no duplicate step updates / stale listeners.
- [ ] `vitest run app/utils/__tests__/indexerEventEmitter.test.ts app/hooks/__tests__/useReducedMotion.test.ts app/utils/__tests__/zeroActivity.test.ts`
- [ ] Enable OS “reduce motion”; check Landing / Loading / Persona / Story — no looping motion, progress still visible.
- [ ] Index a valid account with 0 txs in period → empty state (no mock 420 txs); period/network actions re-run flow.
- [ ] Persona with wallet: Stellar.expert link matches network; without address: link hidden.

closes #239 
closes #249 
closes #254 
closes #260