### PR TITLE
Add channel subscriptions, counts, creators, and DB query indexes

### DIFF
--- a/app/[locale]/share/SharePageClient.tsx
+++ b/app/[locale]/share/SharePageClient.tsx
@@ -245,14 +245,18 @@ export default function SharePageClient() {
 
           <button
             ref={shareBtnRef}
+            type="button"
             onClick={() => setShareOpen(!shareOpen)}
             className="flex h-12 w-12 sm:h-16 sm:w-16 items-center justify-center rounded-full border border-white/10 bg-black/60 text-white backdrop-blur-md transition hover:bg-white/5"
+            aria-label={shareOpen ? "Close share menu" : "Open share menu"}
+            aria-expanded={shareOpen}
+            aria-haspopup="menu"
           >
             <motion.div
               animate={{ rotate: shareOpen ? 50 : 0 }}
               transition={{ type: "spring", stiffness: 260, damping: 20 }}
             >
-              <Share2 className="h-5 w-5 sm:h-7 sm:w-7 cursor-pointer" />
+              <Share2 className="h-5 w-5 sm:h-7 sm:w-7 cursor-pointer" aria-hidden="true" />
             </motion.div>
           </button>
         </div>

--- a/app/api/wrapped/__tests__/route.errors.test.ts
+++ b/app/api/wrapped/__tests__/route.errors.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Unit tests for /api/wrapped safe error responses
+ *
+ * Run with: npx tsx app/api/wrapped/__tests__/route.errors.test.ts
+ *
+ * Verifies that internal error details are not returned to clients
+ * and structured diagnostic codes are preserved.
+ */
+
+let passed = 0;
+let failed = 0;
+const failures: string[] = [];
+
+function assert(condition: boolean, message: string): void {
+  if (condition) {
+    passed++;
+  } else {
+    failed++;
+    failures.push(message);
+    console.error(`  ✗ ${message}`);
+  }
+}
+
+function section(name: string): void {
+  console.log(`\n▸ ${name}`);
+}
+
+/** Mirrors the safe payload shape from app/api/wrapped/route.ts */
+function buildSafeErrorPayload(
+  error: unknown,
+): { status: number; body: { error: string; code: string; details?: string } } {
+  const err = error as Record<string, unknown>;
+  const message = (err?.message as string) || "";
+  const statusCode = err?.statusCode as number | undefined;
+
+  if (
+    message.includes("Not Found") ||
+    message.includes("not found") ||
+    statusCode === 404
+  ) {
+    return {
+      status: 404,
+      body: {
+        error:
+          "Account not found on this network. Make sure you selected the correct network (mainnet/testnet) where the account exists.",
+        code: "ACCOUNT_NOT_FOUND",
+      },
+    };
+  }
+
+  if (statusCode === 429) {
+    return {
+      status: 429,
+      body: { error: "Rate limited. Please try again later.", code: "RATE_LIMITED" },
+    };
+  }
+
+  if (statusCode === 500) {
+    return {
+      status: 500,
+      body: { error: "Horizon server error", code: "HORIZON_ERROR" },
+    };
+  }
+
+  if (message.includes("Bad Request") || statusCode === 400) {
+    return {
+      status: 400,
+      body: { error: "Bad request to Horizon API", code: "BAD_REQUEST" },
+    };
+  }
+
+  return {
+    status: 500,
+    body: {
+      error: "Failed to fetch wrapped data. Please try again later.",
+      code: "WRAPPED_FETCH_FAILED",
+    },
+  };
+}
+
+section("does not leak internal error details on generic 500");
+{
+  const internal = new Error(
+    "ECONNREFUSED 127.0.0.1:5432 password=super-secret stack at indexer.ts:42",
+  );
+  const payload = buildSafeErrorPayload(internal);
+
+  assert(payload.status === 500, "status is 500");
+  assert(payload.body.code === "WRAPPED_FETCH_FAILED", "structured code present");
+  assert(
+    !JSON.stringify(payload.body).includes("ECONNREFUSED"),
+    "does not include connection internals",
+  );
+  assert(
+    !JSON.stringify(payload.body).includes("password="),
+    "does not include secret-like internals",
+  );
+  assert(
+    !("details" in payload.body),
+    "details field is omitted from client payload",
+  );
+  assert(
+    /try again/i.test(payload.body.error),
+    "safe user-facing message returned",
+  );
+}
+
+section("preserves structured codes for known failures");
+{
+  const notFound = buildSafeErrorPayload({
+    message: "Account Not Found",
+    statusCode: 404,
+  });
+  assert(notFound.body.code === "ACCOUNT_NOT_FOUND", "404 → ACCOUNT_NOT_FOUND");
+
+  const rateLimited = buildSafeErrorPayload({ statusCode: 429, message: "Too Many" });
+  assert(rateLimited.body.code === "RATE_LIMITED", "429 → RATE_LIMITED");
+
+  const horizon = buildSafeErrorPayload({ statusCode: 500, message: "boom" });
+  assert(horizon.body.code === "HORIZON_ERROR", "upstream 500 → HORIZON_ERROR");
+}
+
+console.log("\n══════════════════════════════════════════════════════");
+console.log(`  Results:  ${passed} passed, ${failed} failed`);
+console.log("══════════════════════════════════════════════════════");
+
+if (failures.length > 0) {
+  console.log("\nFailed tests:");
+  failures.forEach((f) => console.log(`  ✗ ${f}`));
+}
+
+process.exit(failed > 0 ? 1 : 0);

--- a/app/api/wrapped/route.ts
+++ b/app/api/wrapped/route.ts
@@ -7,6 +7,26 @@ import { NextRequest, NextResponse } from "next/server";
 import { indexAccount } from "@/app/services/indexerService";
 import { WrapPeriod, PERIODS } from "@/app/utils/indexer";
 
+/** Structured codes the frontend can branch on without reading raw internals. */
+export type WrappedApiErrorCode =
+  | "MISSING_ACCOUNT_ID"
+  | "INVALID_ACCOUNT_ID"
+  | "INVALID_NETWORK"
+  | "INVALID_PERIOD"
+  | "ACCOUNT_NOT_FOUND"
+  | "RATE_LIMITED"
+  | "HORIZON_ERROR"
+  | "BAD_REQUEST"
+  | "WRAPPED_FETCH_FAILED";
+
+function errorResponse(
+  status: number,
+  error: string,
+  code: WrappedApiErrorCode,
+) {
+  return NextResponse.json({ error, code }, { status });
+}
+
 export async function GET(request: NextRequest) {
   try {
     const searchParams = request.nextUrl.searchParams;
@@ -17,25 +37,27 @@ export async function GET(request: NextRequest) {
 
     // Validate inputs
     if (!accountId) {
-      return NextResponse.json(
-        { error: "Missing accountId parameter" },
-        { status: 400 },
+      return errorResponse(
+        400,
+        "Missing accountId parameter",
+        "MISSING_ACCOUNT_ID",
       );
     }
 
     if (!accountId.startsWith("G") || accountId.length !== 56) {
-      return NextResponse.json(
-        { error: "Invalid account ID format" },
-        { status: 400 },
+      return errorResponse(
+        400,
+        "Invalid account ID format",
+        "INVALID_ACCOUNT_ID",
       );
     }
 
     if (!["mainnet", "testnet"].includes(network)) {
-      return NextResponse.json({ error: "Invalid network" }, { status: 400 });
+      return errorResponse(400, "Invalid network", "INVALID_NETWORK");
     }
 
     if (!PERIODS[period]) {
-      return NextResponse.json({ error: "Invalid period" }, { status: 400 });
+      return errorResponse(400, "Invalid period", "INVALID_PERIOD");
     }
 
     // indexAccount uses IndexedDB cache internally and returns result + fromCache
@@ -48,6 +70,7 @@ export async function GET(request: NextRequest) {
       refreshingInBackground: response.refreshingInBackground,
     });
   } catch (error: unknown) {
+    // Detailed errors stay server-side only — never leak to clients
     console.error("Error in /api/wrapped:", error);
 
     // Handle specific error cases
@@ -61,46 +84,36 @@ export async function GET(request: NextRequest) {
       message.includes("not found") ||
       statusCode === 404
     ) {
-      return NextResponse.json(
-        {
-          error: "Account not found on this network",
-          details:
-            "Make sure you selected the correct network (mainnet/testnet) where the account exists",
-        },
-        { status: 404 },
+      return errorResponse(
+        404,
+        "Account not found on this network. Make sure you selected the correct network (mainnet/testnet) where the account exists.",
+        "ACCOUNT_NOT_FOUND",
       );
     }
 
     // Check for rate limiting
     if (statusCode === 429) {
-      return NextResponse.json(
-        { error: "Rate limited. Please try again later." },
-        { status: 429 },
+      return errorResponse(
+        429,
+        "Rate limited. Please try again later.",
+        "RATE_LIMITED",
       );
     }
 
     // Check for Horizon server errors
     if (statusCode === 500) {
-      return NextResponse.json(
-        { error: "Horizon server error" },
-        { status: 500 },
-      );
+      return errorResponse(500, "Horizon server error", "HORIZON_ERROR");
     }
 
     // Check for Bad Request (pagination or other API issues)
     if (message.includes("Bad Request") || statusCode === 400) {
-      return NextResponse.json(
-        { error: "Bad Request to Horizon API" },
-        { status: 400 },
-      );
+      return errorResponse(400, "Bad request to Horizon API", "BAD_REQUEST");
     }
 
-    return NextResponse.json(
-      {
-        error: "Failed to fetch wrapped data",
-        details: error instanceof Error ? error.message : String(error),
-      },
-      { status: 500 },
+    return errorResponse(
+      500,
+      "Failed to fetch wrapped data. Please try again later.",
+      "WRAPPED_FETCH_FAILED",
     );
   }
 }

--- a/app/components/ShareCard.tsx
+++ b/app/components/ShareCard.tsx
@@ -66,6 +66,9 @@ export function ShareCard({
     }
 
     if (transactionState === "failed" && transactionError) {
+      // transactionError is already mapped to a friendly message in contractBridge;
+      // keep the raw string in diagnostics for support/debugging.
+      console.error("[ShareCard] mint failed", { transactionError });
       toast.error("Minting failed", {
         description: transactionError,
       });
@@ -199,7 +202,7 @@ export function ShareCard({
       });
     } catch (error) {
       // Errors are handled by transactionObserver setting state to 'failed'
-      // which triggers the useEffect to show a toast, so we just log here.
+      // which triggers the useEffect to show a toast, so we just log raw details here.
       console.error("Minting process caught error:", error);
     }
   };

--- a/app/components/StoryShell.tsx
+++ b/app/components/StoryShell.tsx
@@ -125,10 +125,12 @@ export function StoryShell({ children, activeSegment = 1 }: StoryShellProps) {
       <div className="relative z-50 flex justify-between items-center px-3 sm:px-6 md:px-8 lg:px-12 py-4 sm:py-6 md:py-8 overflow-x-auto">
         {/* Home Button */}
         <motion.button
+          type="button"
           initial={{ opacity: 0, x: -20 }}
           animate={{ opacity: 1, x: 0 }}
           transition={{ delay: 0.2 }}
           onClick={() => router.push("/")}
+          aria-label="Go to home"
         >
           <Home
             className="w-4 h-4 group-hover:scale-110 transition-transform"
@@ -212,9 +214,11 @@ export function StoryShell({ children, activeSegment = 1 }: StoryShellProps) {
       {/* Bottom Controls */}
       <div className="relative z-50 flex justify-between items-center px-3 sm:px-6 md:px-8 lg:px-12 py-4 sm:py-6 md:py-8 gap-4">
         <motion.button
+          type="button"
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.5 }}
+          aria-label="Share wrap"
         >
           <Share2 className="w-5 h-5 text-white/70" aria-hidden="true" />
         </motion.button>
@@ -223,6 +227,7 @@ export function StoryShell({ children, activeSegment = 1 }: StoryShellProps) {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.5 }}
+          aria-label="Next story segment"
         >
           <ChevronRight
             className="w-6 h-6 group-hover:translate-x-1 transition-transform text-white/70"

--- a/app/store/__tests__/wrapStore.test.ts
+++ b/app/store/__tests__/wrapStore.test.ts
@@ -21,28 +21,45 @@ interface WrapResult {
     dapps: DappData[]; vibes: VibeSlice[]; persona: string; personaDescription: string;
 }
 
+interface CacheMeta {
+    fromCache: boolean;
+    cacheTimestamp?: number;
+    refreshingInBackground?: boolean;
+    offline?: boolean;
+}
+
 interface WrapStoreState {
     address: string | null; period: WrapPeriod; network: Network;
     status: WrapStatus; error: string | null; result: WrapResult | null;
+    cacheMeta: CacheMeta | null;
     setAddress: (address: string | null) => void;
     setPeriod: (period: WrapPeriod) => void;
     setNetwork: (network: Network) => void;
     setStatus: (status: WrapStatus) => void;
     setError: (error: string | null) => void;
     setResult: (result: WrapResult | null) => void;
+    setCacheMeta: (meta: CacheMeta | null) => void;
     reset: () => void;
 }
 
 const useWrapStore = create<WrapStoreState>((set) => ({
     address: null, period: 'yearly', network: 'mainnet' as Network,
-    status: 'idle', error: null, result: null,
+    status: 'idle', error: null, result: null, cacheMeta: null,
     setAddress: (address) => set({ address }),
     setPeriod: (period) => set({ period }),
-    setNetwork: (network) => set({ network }),
+    setNetwork: (network) =>
+        set({
+            network,
+            result: null,
+            cacheMeta: null,
+            status: 'idle',
+            error: null,
+        }),
     setStatus: (status) => set({ status }),
     setError: (error) => set({ error }),
     setResult: (result) => set({ result }),
-    reset: () => set({ address: null, period: 'yearly', network: 'mainnet' as Network, status: 'idle', error: null, result: null }),
+    setCacheMeta: (cacheMeta) => set({ cacheMeta }),
+    reset: () => set({ address: null, period: 'yearly', network: 'mainnet' as Network, status: 'idle', error: null, result: null, cacheMeta: null }),
 }));
 
 // ─── Test Helpers ───────────────────────────────────────────────────────────
@@ -115,6 +132,33 @@ section('setNetwork');
 
     useWrapStore.getState().setNetwork('mainnet');
     assert(useWrapStore.getState().network === 'mainnet', 'setNetwork back to mainnet');
+}
+
+// ─── setNetwork clears network-sensitive state ──────────────────────────────
+
+section('setNetwork clears result and cache metadata');
+{
+    useWrapStore.getState().setAddress('GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7');
+    useWrapStore.getState().setPeriod('weekly');
+    useWrapStore.getState().setNetwork('mainnet');
+    useWrapStore.getState().setStatus('ready');
+    useWrapStore.getState().setResult(mockResult);
+    useWrapStore.getState().setCacheMeta({ fromCache: true, cacheTimestamp: Date.now() });
+    useWrapStore.getState().setError('stale network error');
+
+    useWrapStore.getState().setNetwork('testnet');
+    const state = useWrapStore.getState();
+
+    assert(state.network === 'testnet', 'network switched to testnet');
+    assert(state.result === null, 'result cleared on network change');
+    assert(state.cacheMeta === null, 'cacheMeta cleared on network change');
+    assert(state.status === 'idle', 'status reset to idle on network change');
+    assert(state.error === null, 'error cleared on network change');
+    assert(state.period === 'weekly', 'period preference preserved on network change');
+    assert(
+        state.address === 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7',
+        'address preference preserved on network change',
+    );
 }
 
 // ─── setStatus ──────────────────────────────────────────────────────────────

--- a/app/store/wrapStore.ts
+++ b/app/store/wrapStore.ts
@@ -213,7 +213,19 @@ export const useWrapStore = create<WrapStoreState>()(
       ...initialIndexingState,
       setAddress: (address) => set({ address }),
       setPeriod: (period) => set({ period }),
-      setNetwork: (network) => set({ network, ...syncContractState(network) }),
+      setNetwork: (network) => {
+        // Drop previous network's result/cache so stale wrap data cannot leak across networks.
+        // Keep intentional preferences (period, address).
+        resetCache();
+        set({
+          network,
+          ...syncContractState(network),
+          result: null,
+          cacheMeta: null,
+          status: "idle",
+          error: null,
+        });
+      },
       setStatus: (status) => set({ status }),
       setError: (error) => set({ error }),
       setResult: (result) => set({ result }),

--- a/app/utils/__tests__/contractErrors.test.ts
+++ b/app/utils/__tests__/contractErrors.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Unit tests for Soroban contract error → friendly UI mapping
+ *
+ * Run with: npx tsx app/utils/__tests__/contractErrors.test.ts
+ */
+
+import {
+  extractContractErrorCode,
+  mapContractError,
+  getContractErrorUserMessage,
+  SorobanContractErrorCode,
+} from "../contractErrors";
+
+let passed = 0;
+let failed = 0;
+const failures: string[] = [];
+
+function assert(condition: boolean, message: string): void {
+  if (condition) {
+    passed++;
+  } else {
+    failed++;
+    failures.push(message);
+    console.error(`  ✗ ${message}`);
+  }
+}
+
+function section(name: string): void {
+  console.log(`\n▸ ${name}`);
+}
+
+section("extractContractErrorCode");
+{
+  assert(
+    extractContractErrorCode("HostError: Error(Contract, #4)") === 4,
+    "parses Error(Contract, #4)",
+  );
+  assert(
+    extractContractErrorCode("Error(Contract, #6)") === 6,
+    "parses Error(Contract, #6)",
+  );
+  assert(
+    extractContractErrorCode("network timeout") === undefined,
+    "returns undefined when no code present",
+  );
+}
+
+section("mapContractError — WrapAlreadyExists");
+{
+  const mapped = mapContractError(new Error("HostError: Error(Contract, #4)"));
+  assert(mapped.code === "WrapAlreadyExists", "code is WrapAlreadyExists");
+  assert(
+    mapped.numericCode === SorobanContractErrorCode.WrapAlreadyExists,
+    "numeric code is 4",
+  );
+  assert(/already minted/i.test(mapped.userMessage), "friendly duplicate-wrap message");
+  assert(mapped.raw.includes("#4"), "raw details preserved");
+}
+
+section("mapContractError — InvalidSignature");
+{
+  const mapped = mapContractError("simulation failed: Error(Contract, #6)");
+  assert(mapped.code === "InvalidSignature", "code is InvalidSignature");
+  assert(/signature/i.test(mapped.userMessage), "friendly signature message");
+  assert(mapped.raw.includes("#6"), "raw details preserved");
+}
+
+section("mapContractError — unknown host error");
+{
+  const mapped = mapContractError(new Error("HostError: weird trap"));
+  assert(mapped.code === "Unknown", "unknown code");
+  assert(/try again/i.test(mapped.userMessage), "safe fallback message");
+  assert(mapped.raw === "HostError: weird trap", "raw message kept for diagnostics");
+}
+
+section("getContractErrorUserMessage");
+{
+  assert(
+    /opted out/i.test(
+      getContractErrorUserMessage(new Error("Error(Contract, #8)")),
+    ),
+    "returns concise UI string for opted-out",
+  );
+}
+
+console.log("\n══════════════════════════════════════════════════════");
+console.log(`  Results:  ${passed} passed, ${failed} failed`);
+console.log("══════════════════════════════════════════════════════");
+
+if (failures.length > 0) {
+  console.log("\nFailed tests:");
+  failures.forEach((f) => console.log(`  ✗ ${f}`));
+}
+
+process.exit(failed > 0 ? 1 : 0);

--- a/app/utils/contractErrors.ts
+++ b/app/utils/contractErrors.ts
@@ -1,5 +1,9 @@
 /**
- * Errors for network-aware contract loading and validation.
+ * Errors for network-aware contract loading and validation,
+ * plus Soroban ContractError code → friendly UI mapping.
+ *
+ * Codes match stellar-wrap-contract `ContractError` / ERRORS.md:
+ * Error(Contract, #N)
  */
 
 export class ContractConfigurationError extends Error {
@@ -47,4 +51,162 @@ export class NetworkMismatchError extends ContractConfigurationError {
     super(`Network mismatch: expected ${expected}, got ${actual}.`);
     this.name = "NetworkMismatchError";
   }
+}
+
+/** On-chain ContractError variants (stellar-wrap-contract). */
+export enum SorobanContractErrorCode {
+  AlreadyInitialized = 1,
+  NotInitialized = 2,
+  Unauthorized = 3,
+  WrapAlreadyExists = 4,
+  WrapNotFound = 5,
+  InvalidSignature = 6,
+  InvalidDataHash = 7,
+  UserOptedOut = 8,
+}
+
+export type SorobanContractErrorName =
+  | "AlreadyInitialized"
+  | "NotInitialized"
+  | "Unauthorized"
+  | "WrapAlreadyExists"
+  | "WrapNotFound"
+  | "InvalidSignature"
+  | "InvalidDataHash"
+  | "UserOptedOut"
+  | "Unknown";
+
+export interface MappedContractError {
+  /** Structured code for frontend branching (e.g. toast actions). */
+  code: SorobanContractErrorName;
+  /** Numeric on-chain code when known. */
+  numericCode?: number;
+  /** Concise user-facing message for mint/share UI. */
+  userMessage: string;
+  /** Raw host / SDK message for logs and diagnostics. */
+  raw: string;
+}
+
+const CONTRACT_ERROR_PATTERN = /Error\(Contract,\s*#(\d+)\)/i;
+
+const USER_MESSAGES: Record<number, { code: SorobanContractErrorName; userMessage: string }> = {
+  [SorobanContractErrorCode.AlreadyInitialized]: {
+    code: "AlreadyInitialized",
+    userMessage: "This contract is already set up.",
+  },
+  [SorobanContractErrorCode.NotInitialized]: {
+    code: "NotInitialized",
+    userMessage: "The wrap contract is not ready yet. Please try again later.",
+  },
+  [SorobanContractErrorCode.Unauthorized]: {
+    code: "Unauthorized",
+    userMessage: "You are not authorized to complete this action.",
+  },
+  [SorobanContractErrorCode.WrapAlreadyExists]: {
+    code: "WrapAlreadyExists",
+    userMessage: "You already minted a wrap for this period.",
+  },
+  [SorobanContractErrorCode.WrapNotFound]: {
+    code: "WrapNotFound",
+    userMessage: "No wrap was found for this period.",
+  },
+  [SorobanContractErrorCode.InvalidSignature]: {
+    code: "InvalidSignature",
+    userMessage: "Your wrap signature is invalid. Please regenerate and try again.",
+  },
+  [SorobanContractErrorCode.InvalidDataHash]: {
+    code: "InvalidDataHash",
+    userMessage: "Wrap data is invalid. Please refresh your wrap and try again.",
+  },
+  [SorobanContractErrorCode.UserOptedOut]: {
+    code: "UserOptedOut",
+    userMessage: "You have opted out of wraps. Opt back in to mint again.",
+  },
+};
+
+function stringifyError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+/**
+ * Extract numeric Soroban contract error code from a host/SDK message.
+ */
+export function extractContractErrorCode(raw: string): number | undefined {
+  const match = raw.match(CONTRACT_ERROR_PATTERN);
+  if (!match) return undefined;
+  const code = Number.parseInt(match[1], 10);
+  return Number.isFinite(code) ? code : undefined;
+}
+
+/**
+ * Map Soroban / SDK errors to a friendly UI message while keeping raw details.
+ */
+export function mapContractError(error: unknown): MappedContractError {
+  const raw = stringifyError(error);
+  const numericCode = extractContractErrorCode(raw);
+  const mapped = numericCode !== undefined ? USER_MESSAGES[numericCode] : undefined;
+
+  if (mapped) {
+    return {
+      code: mapped.code,
+      numericCode,
+      userMessage: mapped.userMessage,
+      raw,
+    };
+  }
+
+  // Heuristic fallbacks when the host message lacks Error(Contract, #N)
+  const lower = raw.toLowerCase();
+  if (
+    lower.includes("wrapalreadyexists") ||
+    (lower.includes("already exists") && lower.includes("wrap")) ||
+    lower.includes("duplicate wrap")
+  ) {
+    return {
+      code: "WrapAlreadyExists",
+      numericCode: SorobanContractErrorCode.WrapAlreadyExists,
+      userMessage: USER_MESSAGES[SorobanContractErrorCode.WrapAlreadyExists].userMessage,
+      raw,
+    };
+  }
+  if (
+    lower.includes("invalidsignature") ||
+    lower.includes("invalid signature") ||
+    lower.includes("ed25519")
+  ) {
+    return {
+      code: "InvalidSignature",
+      numericCode: SorobanContractErrorCode.InvalidSignature,
+      userMessage: USER_MESSAGES[SorobanContractErrorCode.InvalidSignature].userMessage,
+      raw,
+    };
+  }
+  if (lower.includes("useroptedout") || lower.includes("opted out")) {
+    return {
+      code: "UserOptedOut",
+      numericCode: SorobanContractErrorCode.UserOptedOut,
+      userMessage: USER_MESSAGES[SorobanContractErrorCode.UserOptedOut].userMessage,
+      raw,
+    };
+  }
+
+  return {
+    code: "Unknown",
+    numericCode,
+    userMessage: "Something went wrong with the contract. Please try again.",
+    raw,
+  };
+}
+
+/**
+ * Convenience helper for mint/share UI — returns only the friendly message.
+ */
+export function getContractErrorUserMessage(error: unknown): string {
+  return mapContractError(error).userMessage;
 }

--- a/app/utils/walletKit.ts
+++ b/app/utils/walletKit.ts
@@ -7,6 +7,7 @@ import {
   InvalidContractAddressError,
   ContractNotFoundError,
   ContractValidationError,
+  mapContractError,
 } from "./contractErrors";
 import { mintWrap as contractMintWrap, type MintWrapOptions, type TransactionObserver } from "../../src/services/contractBridge";
 import { useTransactionStore } from "../store/transactionStore";
@@ -239,8 +240,13 @@ export async function mintWrap(params: MintWrapParams): Promise<string> {
     }
     if (error instanceof Error) {
       useTransactionStore.getState().setTransactionState("failed");
-      useTransactionStore.getState().setTransactionError(error.message);
-      throw new Error(`Minting failed: ${error.message}`);
+      // Prefer friendly mapped copy when the error still carries a host Contract #code
+      const mapped = mapContractError(error);
+      const userMessage =
+        mapped.code !== "Unknown" ? mapped.userMessage : error.message;
+      console.error("[walletKit] mint failed", { code: mapped.code, raw: mapped.raw });
+      useTransactionStore.getState().setTransactionError(userMessage);
+      throw new Error(`Minting failed: ${userMessage}`);
     }
     const genericError = new Error("Minting failed: Unknown error occurred");
     useTransactionStore.getState().setTransactionState("failed");

--- a/src/services/contractBridge.ts
+++ b/src/services/contractBridge.ts
@@ -12,6 +12,7 @@ import { signTransaction } from '@stellar/freighter-api';
 import { Network, NETWORK_PASSPHRASES, SOROBAN_RPC_URLS, RPC_ENDPOINTS } from '../config';
 import { getContractAddress } from '../../config/contracts';
 import { buildContractArgs, type ContractStatsInput } from '../utils/contractArgsBuilder';
+import { mapContractError } from '../../app/utils/contractErrors';
 
 export type TransactionState =
   | 'pending'
@@ -172,20 +173,36 @@ async function waitForConfirmation(
   );
 }
 
+/**
+ * Map SDK / host errors to concise user-facing copy.
+ * Raw details stay available via `mapContractError(...).raw` for logs.
+ */
 function parseContractError(error: unknown): string {
+  const mapped = mapContractError(error);
+  // Always keep raw details in diagnostics/logs
+  if (mapped.code !== 'Unknown') {
+    console.warn('[contractBridge] contract error', {
+      code: mapped.code,
+      numericCode: mapped.numericCode,
+      raw: mapped.raw,
+    });
+    return mapped.userMessage;
+  }
+
   if (error instanceof Error) {
     const message = error.message;
     if (message.includes('insufficient_fee') || message.includes('fee')) {
       return 'Insufficient transaction fee. Please try again.';
-    }
-    if (message.includes('HostError') || message.includes('ContractError')) {
-      return `Contract error: ${message}`;
     }
     if (message.includes('User declined') || message.includes('rejected')) {
       return 'Transaction was rejected by user';
     }
     if (message.includes('network') || message.includes('timeout')) {
       return 'Network error. Please check your connection and try again.';
+    }
+    if (message.includes('HostError') || message.includes('ContractError') || message.includes('Error(Contract')) {
+      console.warn('[contractBridge] unmapped host error', mapped.raw);
+      return mapped.userMessage;
     }
     return message;
   }

--- a/tests/e2e/accessibility-icon-buttons.spec.ts
+++ b/tests/e2e/accessibility-icon-buttons.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Accessibility regression: icon-only controls must expose meaningful names.
+ * Covers mute, share, palette, next, and home controls called out in the a11y task.
+ */
+test.describe("Icon-only button accessible names", () => {
+  test("mute toggle exposes mute/unmute name", async ({ page }) => {
+    await page.goto("/share");
+
+    const mute = page.getByRole("button", { name: /mute sounds|unmute sounds/i });
+    await expect(mute).toBeVisible();
+
+    const labelBefore = await mute.getAttribute("aria-label");
+    await mute.click();
+    const labelAfter = await mute.getAttribute("aria-label");
+    expect(labelBefore).toBeTruthy();
+    expect(labelAfter).toBeTruthy();
+    expect(labelAfter).not.toEqual(labelBefore);
+  });
+
+  test("share page share control has an accessible name", async ({ page }) => {
+    await page.goto("/share");
+
+    const share = page.getByRole("button", {
+      name: /open share menu|close share menu/i,
+    });
+    await expect(share).toBeVisible();
+  });
+
+  test("story shell icon controls expose home, palette, share, and next names", async ({
+    page,
+  }) => {
+    // Story shell is used across story steps; top-daps is a representative surface.
+    await page.goto("/top-daps");
+
+    // Prefer role queries; fall back to aria-label locators if the shell is nested.
+    const home = page.locator('button[aria-label="Go to home"]');
+    const palette = page.locator('button[aria-label="Open color theme picker"]');
+    const share = page.locator('button[aria-label="Share wrap"]');
+    const next = page.locator('button[aria-label="Next story segment"]');
+
+    // Soft presence: page may redirect when wrap state is empty; assert attributes when mounted.
+    const shellPresent = (await home.count()) > 0;
+    test.skip(!shellPresent, "StoryShell not mounted on this route without wrap state");
+
+    await expect(home).toHaveAttribute("aria-label", "Go to home");
+    await expect(palette).toHaveAttribute("aria-label", "Open color theme picker");
+    await expect(share).toHaveAttribute("aria-label", "Share wrap");
+    await expect(next).toHaveAttribute("aria-label", "Next story segment");
+  });
+});


### PR DESCRIPTION
## Summary
Hardens session safety and user-facing errors across network switches, Soroban mint/share failures, and the wrapped API, and adds accessible names for icon-only controls.

## Changes

### 1. fix(network): clear result and cache metadata when network changes
Changing network no longer leaves the previous network’s wrap result, cache metadata, status/error, or contract address state on screen.

- `setNetwork` in `app/store/wrapStore.ts` now resets `result`, `cacheMeta`, `status`, and `error`, re-syncs contract addresses for the new network, and clears the in-memory indexer cache via `resetCache()`.
- Intentional preferences (`period`, `address`) are preserved.
- `NetworkToggle` continues to clear the contract instance cache; store cleanup covers session result/cache state.
- Added store coverage in `app/store/__tests__/wrapStore.test.ts` for network-switch cleanup.

### 2. fix(contract): map Soroban contract errors to friendly UI messages
Raw host messages like `Error(Contract, #4)` / `#6` no longer surface directly in mint/share UI.

- Extended `app/utils/contractErrors.ts` with `ContractError` code mapping aligned to stellar-wrap-contract (`AlreadyInitialized`…`UserOptedOut`).
- `mapContractError()` returns `{ code, numericCode, userMessage, raw }` so UI can show concise copy while logs keep diagnostics.
- `src/services/contractBridge.ts` and `app/utils/walletKit.ts` use the mapper in mint failure paths; ShareCard logs raw failure context and shows the mapped message.
- Unit tests in `app/utils/__tests__/contractErrors.test.ts`.

### 3. fix(api): avoid leaking internal error details to users
`/api/wrapped` no longer returns raw `details` from caught exceptions on 500s.

- Client responses use safe `error` strings plus structured `code` values (`ACCOUNT_NOT_FOUND`, `RATE_LIMITED`, `HORIZON_ERROR`, `WRAPPED_FETCH_FAILED`, etc.).
- Full errors remain `console.error`’d server-side only.
- Coverage in `app/api/wrapped/__tests__/route.errors.test.ts`.

### 4. feat(accessibility): add accessible names to icon-only buttons
Icon-only controls now expose meaningful accessible names.

- `StoryShell`: `Go to home`, `Share wrap`, `Next story segment` (palette already labeled).
- Share page floating share control: `Open share menu` / `Close share menu` (+ `aria-expanded`).
- `MuteToggle` already exposes mute/unmute labels.
- Playwright regression: `tests/e2e/accessibility-icon-buttons.spec.ts`.

## Test plan
- [ ] Switch mainnet ↔ testnet with an existing wrap result; confirm result/cache badge clear and period stays the same
- [ ] Trigger mint failures for duplicate wrap (`#4`) and invalid signature (`#6`); confirm friendly toasts and console diagnostics
- [ ] Force `/api/wrapped` 500; confirm response has safe `error` + `code`, no internal `details`
- [ ] Keyboard/screen-reader check mute, share, palette, home, next controls
- [ ] `npx tsx app/store/__tests__/wrapStore.test.ts`
- [ ] `npx tsx app/utils/__tests__/contractErrors.test.ts`
- [ ] `npx tsx app/api/wrapped/__tests__/route.errors.test.ts`
- [ ] `npx playwright test tests/e2e/accessibility-icon-buttons.spec.ts`

closes #225 
closes #229 
closes #247 
closes #250