### PR TITLE
test(indexer): add rate-limit API route test (#289)

### DIFF
--- a/app/api/wrapped/__tests__/route.test.ts
+++ b/app/api/wrapped/__tests__/route.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Unit tests for the wrapped API route rate limiting
+ * Tests that Horizon 429 rate-limit responses are handled correctly
+ */
+
+import { GET } from '../route';
+import { indexAccount } from '@/app/services/indexerService';
+import { NextRequest } from 'next/server';
+
+jest.mock('@/app/services/indexerService', () => ({
+  indexAccount: jest.fn(),
+}));
+
+jest.mock('@/app/utils/indexer', () => ({
+  PERIODS: {
+    weekly: 7,
+    biweekly: 14,
+    monthly: 30,
+    yearly: 365,
+  },
+}));
+
+const mockIndexAccount = indexAccount as jest.Mock;
+
+function createRequest(params: Record<string, string>) {
+  const url = new URL('http://localhost/api/wrapped');
+  Object.entries(params).forEach(([key, value]) => url.searchParams.set(key, value));
+  return new NextRequest(url);
+}
+
+// Valid Stellar account ID (56 chars, starts with G)
+const VALID_ACCOUNT_ID = 'GABCDEF1234567890123456789012345678901234567890123456789';
+
+describe('GET /api/wrapped - Rate Limiting', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return 429 with retry-friendly message when indexAccount throws 429 error', async () => {
+    const rateLimitError = new Error('Rate limit exceeded (429). Please try again later.');
+    (rateLimitError as any).statusCode = 429;
+    mockIndexAccount.mockRejectedValue(rateLimitError);
+
+    const request = createRequest({
+      accountId: VALID_ACCOUNT_ID,
+      network: 'mainnet',
+      period: 'monthly',
+    });
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(429);
+    expect(data.error).toBe('Rate limited. Please try again later.');
+  });
+
+  it('should return 429 when error message contains "Rate limit"', async () => {
+    const rateLimitError = new Error('Rate limit exceeded. Try again later.');
+    (rateLimitError as any).statusCode = 429;
+    mockIndexAccount.mockRejectedValue(rateLimitError);
+
+    const request = createRequest({
+      accountId: VALID_ACCOUNT_ID,
+      network: 'mainnet',
+      period: 'monthly',
+    });
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(429);
+    expect(data.error).toBe('Rate limited. Please try again later.');
+  });
+
+  it('should return 429 when error has statusCode 429 property', async () => {
+    const error = new Error('Too Many Requests');
+    (error as any).statusCode = 429;
+    mockIndexAccount.mockRejectedValue(error);
+
+    const request = createRequest({
+      accountId: VALID_ACCOUNT_ID,
+      network: 'mainnet',
+      period: 'monthly',
+    });
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(429);
+    expect(data.error).toBe('Rate limited. Please try again later.');
+  });
+
+  it('should return 404 for account not found', async () => {
+    const notFoundError = new Error('Not Found');
+    (notFoundError as any).statusCode = 404;
+    mockIndexAccount.mockRejectedValue(notFoundError);
+
+    const request = createRequest({
+      accountId: VALID_ACCOUNT_ID,
+      network: 'mainnet',
+      period: 'monthly',
+    });
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error).toBe('Account not found on this network');
+  });
+
+  it('should return 500 for Horizon server errors', async () => {
+    const serverError = new Error('Internal Server Error');
+    (serverError as any).statusCode = 500;
+    mockIndexAccount.mockRejectedValue(serverError);
+
+    const request = createRequest({
+      accountId: VALID_ACCOUNT_ID,
+      network: 'mainnet',
+      period: 'monthly',
+    });
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe('Horizon server error');
+  });
+
+  it('should return 400 for bad request errors', async () => {
+    const badRequestError = new Error('Bad Request');
+    (badRequestError as any).statusCode = 400;
+    mockIndexAccount.mockRejectedValue(badRequestError);
+
+    const request = createRequest({
+      accountId: VALID_ACCOUNT_ID,
+      network: 'mainnet',
+      period: 'monthly',
+    });
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('Bad Request to Horizon API');
+  });
+
+  it('should return 400 for missing accountId', async () => {
+    const request = createRequest({
+      network: 'mainnet',
+      period: 'monthly',
+    });
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('Missing accountId parameter');
+  });
+
+  it('should return 400 for invalid accountId format', async () => {
+    const request = createRequest({
+      accountId: 'INVALID_ACCOUNT',
+      network: 'mainnet',
+      period: 'monthly',
+    });
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('Invalid account ID format');
+  });
+
+  it('should return 400 for invalid network', async () => {
+    const request = createRequest({
+      accountId: VALID_ACCOUNT_ID,
+      network: 'invalid',
+      period: 'monthly',
+    });
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('Invalid network');
+  });
+
+  it('should return 400 for invalid period', async () => {
+    const request = createRequest({
+      accountId: VALID_ACCOUNT_ID,
+      network: 'mainnet',
+      period: 'invalid',
+    });
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('Invalid period');
+  });
+
+  it('should return 500 for unknown errors', async () => {
+    const unknownError = new Error('Unknown error');
+    mockIndexAccount.mockRejectedValue(unknownError);
+
+    const request = createRequest({
+      accountId: VALID_ACCOUNT_ID,
+      network: 'mainnet',
+      period: 'monthly',
+    });
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe('Failed to fetch wrapped data');
+    expect(data.details).toBe('Unknown error');
+  });
+
+  it('should return successful response with cached data', async () => {
+    const mockResult = {
+      accountId: 'GABCDEF12345678901234567890123456789012345678901234567890',
+      totalTransactions: 10,
+      totalVolume: 1000,
+      mostActiveAsset: 'XLM',
+      contractCalls: 0,
+      gasSpent: 0,
+      dapps: [],
+      vibes: [],
+    };
+
+    mockIndexAccount.mockResolvedValue({
+      result: mockResult,
+      fromCache: true,
+      cacheTimestamp: Date.now(),
+    });
+
+    const request = createRequest({
+      accountId: VALID_ACCOUNT_ID,
+      network: 'mainnet',
+      period: 'monthly',
+    });
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.cached).toBe(true);
+    expect(data.totalTransactions).toBe(10);
+  });
+
+  it('should return successful response with fresh data', async () => {
+    const mockResult = {
+      accountId: 'GABCDEF12345678901234567890123456789012345678901234567890',
+      totalTransactions: 5,
+      totalVolume: 500,
+      mostActiveAsset: 'USDC',
+      contractCalls: 2,
+      gasSpent: 100,
+      dapps: ['dapp1'],
+      vibes: ['vibe1'],
+    };
+
+    mockIndexAccount.mockResolvedValue({
+      result: mockResult,
+      fromCache: false,
+    });
+
+    const request = createRequest({
+      accountId: 'GABCDEF1234567890123456789012345678901234567890123456789',
+      network: 'testnet',
+      period: 'weekly',
+    });
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.cached).toBe(false);
+    expect(data.totalTransactions).toBe(5);
+    expect(data.mostActiveAsset).toBe('USDC');
+  });
+
+  it('should return refreshingInBackground when cache is stale', async () => {
+    const mockResult = {
+      accountId: 'GABCDEF12345678901234567890123456789012345678901234567890',
+      totalTransactions: 8,
+      totalVolume: 800,
+      mostActiveAsset: 'XLM',
+      contractCalls: 1,
+      gasSpent: 50,
+      dapps: [],
+      vibes: [],
+    };
+
+    mockIndexAccount.mockResolvedValue({
+      result: mockResult,
+      fromCache: true,
+      cacheTimestamp: Date.now() - 100000,
+      refreshingInBackground: true,
+    });
+
+    const request = createRequest({
+      accountId: VALID_ACCOUNT_ID,
+      network: 'mainnet',
+      period: 'monthly',
+    });
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.refreshingInBackground).toBe(true);
+    expect(data.cached).toBe(true);
+  });
+});

--- a/app/api/wrapped/__tests__/route.test.ts
+++ b/app/api/wrapped/__tests__/route.test.ts
@@ -7,6 +7,10 @@ import { GET } from '../route';
 import { indexAccount } from '@/app/services/indexerService';
 import { NextRequest } from 'next/server';
 
+interface MockError extends Error {
+  statusCode?: number;
+}
+
 jest.mock('@/app/services/indexerService', () => ({
   indexAccount: jest.fn(),
 }));
@@ -21,6 +25,10 @@ jest.mock('@/app/utils/indexer', () => ({
 }));
 
 const mockIndexAccount = indexAccount as jest.Mock;
+
+interface MockError extends Error {
+  statusCode?: number;
+}
 
 function createRequest(params: Record<string, string>) {
   const url = new URL('http://localhost/api/wrapped');
@@ -38,7 +46,7 @@ describe('GET /api/wrapped - Rate Limiting', () => {
 
   it('should return 429 with retry-friendly message when indexAccount throws 429 error', async () => {
     const rateLimitError = new Error('Rate limit exceeded (429). Please try again later.');
-    (rateLimitError as any).statusCode = 429;
+    (rateLimitError as MockError).statusCode = 429;
     mockIndexAccount.mockRejectedValue(rateLimitError);
 
     const request = createRequest({
@@ -56,7 +64,7 @@ describe('GET /api/wrapped - Rate Limiting', () => {
 
   it('should return 429 when error message contains "Rate limit"', async () => {
     const rateLimitError = new Error('Rate limit exceeded. Try again later.');
-    (rateLimitError as any).statusCode = 429;
+    (rateLimitError as MockError).statusCode = 429;
     mockIndexAccount.mockRejectedValue(rateLimitError);
 
     const request = createRequest({
@@ -74,7 +82,7 @@ describe('GET /api/wrapped - Rate Limiting', () => {
 
   it('should return 429 when error has statusCode 429 property', async () => {
     const error = new Error('Too Many Requests');
-    (error as any).statusCode = 429;
+    (error as MockError).statusCode = 429;
     mockIndexAccount.mockRejectedValue(error);
 
     const request = createRequest({
@@ -92,7 +100,7 @@ describe('GET /api/wrapped - Rate Limiting', () => {
 
   it('should return 404 for account not found', async () => {
     const notFoundError = new Error('Not Found');
-    (notFoundError as any).statusCode = 404;
+    (notFoundError as MockError).statusCode = 404;
     mockIndexAccount.mockRejectedValue(notFoundError);
 
     const request = createRequest({
@@ -110,7 +118,7 @@ describe('GET /api/wrapped - Rate Limiting', () => {
 
   it('should return 500 for Horizon server errors', async () => {
     const serverError = new Error('Internal Server Error');
-    (serverError as any).statusCode = 500;
+    (serverError as MockError).statusCode = 500;
     mockIndexAccount.mockRejectedValue(serverError);
 
     const request = createRequest({
@@ -128,7 +136,7 @@ describe('GET /api/wrapped - Rate Limiting', () => {
 
   it('should return 400 for bad request errors', async () => {
     const badRequestError = new Error('Bad Request');
-    (badRequestError as any).statusCode = 400;
+    (badRequestError as MockError).statusCode = 400;
     mockIndexAccount.mockRejectedValue(badRequestError);
 
     const request = createRequest({

--- a/app/components/RateLimitBanner.test.tsx
+++ b/app/components/RateLimitBanner.test.tsx
@@ -1,0 +1,213 @@
+/**
+ * Unit tests for RateLimitBanner component
+ * Tests rendering and behavior for rate-limited API responses
+ */
+
+import { render, screen, act } from '@testing-library/react';
+import { RateLimitBanner } from './RateLimitBanner';
+import { useRateLimitStore } from '@/src/store/rateLimitStore';
+
+// Mock the store
+jest.mock('@/src/store/rateLimitStore', () => ({
+  useRateLimitStore: jest.fn(),
+}));
+
+const mockUseRateLimitStore = useRateLimitStore as jest.Mock;
+
+describe('RateLimitBanner', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const mockStore = (overrides: Partial<{
+    isRateLimited: boolean;
+    resetTime: number | null;
+    retryAttempt: number;
+    message: string | null;
+  }> = {}) => {
+    mockUseRateLimitStore.mockReturnValue({
+      isRateLimited: false,
+      resetTime: null,
+      retryAttempt: 0,
+      message: null,
+      ...overrides,
+    });
+  };
+
+  it('renders nothing when not rate limited and not retrying', () => {
+    mockStore({ isRateLimited: false, retryAttempt: 0 });
+
+    render(<RateLimitBanner />);
+
+    expect(screen.queryByText('Rate Limit Reached')).not.toBeInTheDocument();
+    expect(screen.queryByText('API Congestion')).not.toBeInTheDocument();
+  });
+
+  it('renders rate limit banner when isRateLimited is true', () => {
+    const resetTime = Date.now() + 30000; // 30 seconds from now
+    mockStore({ isRateLimited: true, resetTime, retryAttempt: 0 });
+
+    render(<RateLimitBanner />);
+
+    expect(screen.getByText('Rate Limit Reached')).toBeInTheDocument();
+    expect(screen.getByText(/Horizon is taking a breather/)).toBeInTheDocument();
+    expect(screen.getByText(/Resuming in \d+s/)).toBeInTheDocument();
+  });
+
+  it('renders countdown timer when rate limited', () => {
+    const resetTime = Date.now() + 45000; // 45 seconds from now
+    mockStore({ isRateLimited: true, resetTime, retryAttempt: 0 });
+
+    render(<RateLimitBanner />);
+
+    // Find the countdown element with exact text match
+    const countdownText = screen.getAllByText(/45s/);
+    expect(countdownText.length).toBeGreaterThan(0);
+  });
+
+  it('renders retrying banner when retryAttempt > 0', () => {
+    mockStore({
+      isRateLimited: false,
+      resetTime: null,
+      retryAttempt: 2,
+      message: 'Retrying connection...',
+    });
+
+    render(<RateLimitBanner />);
+
+    expect(screen.getByText('API Congestion')).toBeInTheDocument();
+    expect(screen.getByText(/Retrying connection/)).toBeInTheDocument();
+  });
+
+  it('displays custom message when retrying', () => {
+    mockStore({
+      isRateLimited: false,
+      resetTime: null,
+      retryAttempt: 1,
+      message: 'Custom retry message',
+    });
+
+    render(<RateLimitBanner />);
+
+    expect(screen.getByText('Custom retry message')).toBeInTheDocument();
+  });
+
+  it('shows AlertTriangle icon when rate limited', () => {
+    const resetTime = Date.now() + 30000;
+    mockStore({ isRateLimited: true, resetTime, retryAttempt: 0 });
+
+    render(<RateLimitBanner />);
+
+    // Check for the AlertTriangle SVG icon by class name (aria-hidden makes it inaccessible via role)
+    const alertIcon = screen.getByTestId('rate-limit-alert-icon');
+    expect(alertIcon).toBeInTheDocument();
+  });
+
+  it('shows RotateCcw icon when retrying', () => {
+    mockStore({
+      isRateLimited: false,
+      resetTime: null,
+      retryAttempt: 2,
+      message: 'Retrying...',
+    });
+
+    render(<RateLimitBanner />);
+
+    // Check for the RotateCcw SVG icon by class name (aria-hidden makes it inaccessible via role)
+    const rotateIcon = screen.getByTestId('rate-limit-retry-icon');
+    expect(rotateIcon).toBeInTheDocument();
+  });
+
+  it('shows Clock icon with countdown when rate limited', () => {
+    const resetTime = Date.now() + 30000;
+    mockStore({ isRateLimited: true, resetTime, retryAttempt: 0 });
+
+    render(<RateLimitBanner />);
+
+    // Check for the Clock SVG icon by class name (aria-hidden makes it inaccessible via role)
+    const clockIcon = screen.getByTestId('rate-limit-clock-icon');
+    expect(clockIcon).toBeInTheDocument();
+    // Check for countdown text in the clock container - use the span with font-mono class
+    const countdownSpan = clockIcon.closest('div')?.querySelector('span.text-xs.font-mono');
+    expect(countdownSpan).toBeInTheDocument();
+    expect(countdownSpan).toHaveTextContent(/30s/);
+  });
+
+  it('updates countdown as time passes', () => {
+    const initialResetTime = Date.now() + 30000;
+    mockStore({ isRateLimited: true, resetTime: initialResetTime, retryAttempt: 0 });
+
+    render(<RateLimitBanner />);
+
+    // Find the countdown span element
+    const countdownElements = screen.getAllByText(/30s/);
+    expect(countdownElements.length).toBeGreaterThan(0);
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    // Should update to 25s
+    const updatedCountdown = screen.getAllByText(/25s/);
+    expect(updatedCountdown.length).toBeGreaterThan(0);
+  });
+
+  it('applies red gradient background when rate limited', () => {
+    const resetTime = Date.now() + 30000;
+    mockStore({ isRateLimited: true, resetTime, retryAttempt: 0 });
+
+    render(<RateLimitBanner />);
+
+    const banner = screen.getByText('Rate Limit Reached').closest('div');
+    expect(banner).toHaveStyle({ background: expect.stringContaining('linear-gradient') });
+  });
+
+  it('applies blue gradient background when retrying', () => {
+    mockStore({
+      isRateLimited: false,
+      resetTime: null,
+      retryAttempt: 2,
+      message: 'Retrying...',
+    });
+
+    render(<RateLimitBanner />);
+
+    const banner = screen.getByText('API Congestion').closest('div');
+    expect(banner).toHaveStyle({ background: expect.stringContaining('linear-gradient') });
+  });
+
+  it('hides banner when rate limit clears', () => {
+    const resetTime = Date.now() + 30000;
+    mockStore({ isRateLimited: true, resetTime, retryAttempt: 0 });
+
+    const { unmount } = render(<RateLimitBanner />);
+
+    expect(screen.getByText('Rate Limit Reached')).toBeInTheDocument();
+
+    unmount();
+
+    mockStore({ isRateLimited: false, resetTime: null, retryAttempt: 0 });
+    render(<RateLimitBanner />);
+
+    expect(screen.queryByText('Rate Limit Reached')).not.toBeInTheDocument();
+  });
+
+  it('renders progress bar animation when retrying', () => {
+    mockStore({
+      isRateLimited: false,
+      resetTime: null,
+      retryAttempt: 1,
+      message: 'Retrying...',
+    });
+
+    render(<RateLimitBanner />);
+
+    // The animated progress bar should be present when retrying
+    expect(screen.getByText('API Congestion')).toBeInTheDocument();
+  });
+});

--- a/app/components/RateLimitBanner.tsx
+++ b/app/components/RateLimitBanner.tsx
@@ -29,7 +29,7 @@ export function RateLimitBanner() {
                             {/* Icon */}
                             <div className={`flex h-10 w-10 items-center justify-center rounded-xl ${isRateLimited ? 'bg-red-500/20 text-red-500' : 'bg-primary/20 text-theme-primary'
                                 }`}>
-                                {isRateLimited ? <AlertTriangle className="w-6 h-6" /> : <RotateCcw className="w-5 h-5 animate-spin" />}
+                                {isRateLimited ? <AlertTriangle className="w-6 h-6" data-testid="rate-limit-alert-icon" /> : <RotateCcw className="w-5 h-5 animate-spin" data-testid="rate-limit-retry-icon" />}
                             </div>
 
                             {/* Text */}
@@ -47,7 +47,7 @@ export function RateLimitBanner() {
                             {/* Countdown/Status */}
                             {isRateLimited && secondsRemaining !== null && (
                                 <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-white/5 border border-white/10">
-                                    <Clock className="w-3 h-3 text-white/40" />
+                                    <Clock className="w-3 h-3 text-white/40" data-testid="rate-limit-clock-icon" />
                                     <span className="text-xs font-mono font-bold text-white">
                                         {secondsRemaining}s
                                     </span>

--- a/jest.config.components.js
+++ b/jest.config.components.js
@@ -1,0 +1,25 @@
+import nextJest from 'next/jest.js';
+
+const createJestConfig = nextJest({
+  dir: './',
+});
+
+/** @type {import('jest').Config} */
+const customJestConfig = {
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+  },
+  testMatch: [
+    '**/app/components/**/*.test.tsx',
+  ],
+  transform: {
+    '^.+\\.(ts|tsx|js|jsx)$': ['ts-jest', {
+      tsconfig: 'tsconfig.json',
+    }],
+  },
+  modulePathIgnorePatterns: ['<rootDir>/.next/'],
+};
+
+export default createJestConfig(customJestConfig);

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,2 +1,3 @@
 // Jest setup file for global test configuration
 // Add any global test utilities, mocks, or configurations here
+import '@testing-library/jest-dom';


### PR DESCRIPTION
Closes #289. Mocks Horizon 429 rate-limit responses to verify API route returns clean HTTP 429 status with retry-friendly messaging and validates RateLimitBanner UI rendering.