### PR TITLE
test(connect): add manual address validation scenarios

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "next-version",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "pnpm@9.0.0",
+  "packageManager": "pnpm@10.25.0",
   "engines": {
     "node": ">=18.0.0",
     "pnpm": ">=9.0.0"
@@ -42,23 +42,25 @@
     "zustand": "^5.0.10"
   },
   "devDependencies": {
-    "autocannon": "7.15.0",
+    "@playwright/test": "^1.61.1",
+    "@testing-library/jest-dom": "^7.0.0",
+    "@testing-library/react": "^16.3.2",
     "@types/canvas-confetti": "^1.9.0",
     "@types/jest": "^29.5.14",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@playwright/test": "^1.61.1",
     "@vitest/ui": "^4.0.18",
     "ansi-styles": "^6.2.1",
+    "autocannon": "7.15.0",
     "eslint": "^9",
     "eslint-config-next": "16.1.4",
     "husky": "^9.0.0",
     "jest": "^29",
+    "jest-environment-jsdom": "^30.4.1",
     "tailwindcss": "^4",
     "ts-jest": "^29.4.6",
     "typescript": "^5",
     "vitest": "^4.1.9"
-  },
-  "packageManager": "pnpm@10.25.0"
+  }
 }

--- a/src/hooks/__tests__/useStellarAddressValidation.test.tsx
+++ b/src/hooks/__tests__/useStellarAddressValidation.test.tsx
@@ -1,0 +1,294 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Tests for useStellarAddressValidation hook
+ *
+ * Covers the three acceptance criteria for manual address entry:
+ *   1. Empty input → idle state (would trigger "required error" in the page)
+ *   2. Invalid checksum → invalid-format state (blocks navigation)
+ *   3. Valid address → valid state after debounce (routes to loading)
+ *
+ * Run with: npm test -- --testPathPattern=useStellarAddressValidation
+ */
+
+import { renderHook, act } from "@testing-library/react";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+const VALID_ADDRESS = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7";
+const VALID_ADDRESS_2 = "GAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN70";
+
+const ALL_VALID = [VALID_ADDRESS, VALID_ADDRESS_2];
+
+const mockLoadAccount = jest.fn();
+
+jest.mock("stellar-sdk", () => ({
+  StrKey: {
+    isValidEd25519PublicKey: jest.fn((addr: string) => {
+      return ALL_VALID.includes(addr);
+    }),
+    isValidMed25519PublicKey: jest.fn(() => false),
+  },
+  Horizon: {
+    Server: jest.fn().mockImplementation(() => ({
+      loadAccount: mockLoadAccount,
+    })),
+  },
+}));
+
+jest.mock("../../config", () => ({
+  RPC_ENDPOINTS: {
+    mainnet: "https://horizon.stellar.org",
+    testnet: "https://horizon-testnet.stellar.org",
+  },
+}));
+
+// Import after mocks are set up
+import { useStellarAddressValidation } from "../useStellarAddressValidation";
+import { StrKey } from "stellar-sdk";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function renderHookWithDefaults(overrides = {}) {
+  return renderHook(() =>
+    useStellarAddressValidation({ network: "mainnet", debounceMs: 50, ...overrides })
+  );
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("useStellarAddressValidation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe("empty input → idle state (acceptance: empty submit shows required error)", () => {
+    it("starts in idle state with empty address", () => {
+      const { result } = renderHookWithDefaults();
+
+      expect(result.current.address).toBe("");
+      expect(result.current.validationState).toBe("idle");
+      expect(result.current.isValid).toBe(false);
+      expect(result.current.errorMessage).toBeNull();
+    });
+
+    it("returns to idle when address is cleared", () => {
+      const { result } = renderHookWithDefaults();
+
+      act(() => {
+        result.current.handleAddressChange(VALID_ADDRESS);
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(50);
+      });
+
+      act(() => {
+        result.current.handleAddressChange("");
+      });
+
+      expect(result.current.address).toBe("");
+      expect(result.current.validationState).toBe("idle");
+      expect(result.current.isValid).toBe(false);
+    });
+
+    it("returns to idle when only whitespace is entered", () => {
+      const { result } = renderHookWithDefaults();
+
+      act(() => {
+        result.current.handleAddressChange("   ");
+      });
+
+      expect(result.current.validationState).toBe("idle");
+      expect(result.current.isValid).toBe(false);
+    });
+  });
+
+  describe("invalid checksum → invalid-format state (acceptance: blocks navigation)", () => {
+    it("rejects address with wrong checksum (56 chars, G prefix)", () => {
+      const { result } = renderHookWithDefaults();
+
+      const badChecksum = "G" + "A".repeat(55);
+
+      act(() => {
+        result.current.handleAddressChange(badChecksum);
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(50);
+      });
+
+      expect(result.current.isValid).toBe(false);
+      expect(result.current.validationState).toBe("invalid-format");
+      expect(StrKey.isValidEd25519PublicKey).toHaveBeenCalledWith(badChecksum);
+    });
+
+    it("rejects address with wrong length", () => {
+      const { result } = renderHookWithDefaults();
+
+      act(() => {
+        result.current.handleAddressChange("GABC");
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(50);
+      });
+
+      expect(result.current.isValid).toBe(false);
+      expect(result.current.validationState).toBe("invalid-format");
+    });
+
+    it("rejects address with wrong prefix (S = secret key)", () => {
+      const { result } = renderHookWithDefaults();
+
+      act(() => {
+        result.current.handleAddressChange("SBCXOGZJR2O4XQ2D6K5D4Z5J3RFLBZ2N6K5D4Z5");
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(50);
+      });
+
+      expect(result.current.isValid).toBe(false);
+      expect(result.current.validationState).toBe("invalid-format");
+    });
+
+    it("does not call Horizon loadAccount for invalid format", () => {
+      const { result } = renderHookWithDefaults();
+
+      act(() => {
+        result.current.handleAddressChange("GABC");
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(50);
+      });
+
+      expect(mockLoadAccount).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("valid address → valid state (acceptance: stores trimmed value and routes to loading)", () => {
+    it("transitions to valid after format + network check pass", async () => {
+      mockLoadAccount.mockResolvedValueOnce({ account_id: VALID_ADDRESS });
+
+      const { result } = renderHookWithDefaults();
+
+      act(() => {
+        result.current.handleAddressChange(VALID_ADDRESS);
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(50);
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(result.current.isValid).toBe(true);
+      expect(result.current.validationState).toBe("valid");
+      expect(result.current.errorMessage).toBeNull();
+    });
+
+    it("stores trimmed address (removes whitespace)", async () => {
+      mockLoadAccount.mockResolvedValueOnce({ account_id: VALID_ADDRESS });
+
+      const { result } = renderHookWithDefaults();
+
+      act(() => {
+        result.current.handleAddressChange(`  ${VALID_ADDRESS}  `);
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(50);
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(result.current.address).toBe(VALID_ADDRESS);
+      expect(result.current.isValid).toBe(true);
+    });
+
+    it("calls Horizon loadAccount for valid format", async () => {
+      mockLoadAccount.mockResolvedValueOnce({ account_id: VALID_ADDRESS_2 });
+
+      const { result } = renderHookWithDefaults();
+
+      act(() => {
+        result.current.handleAddressChange(VALID_ADDRESS_2);
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(50);
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockLoadAccount).toHaveBeenCalledWith(VALID_ADDRESS_2);
+      expect(result.current.isValid).toBe(true);
+    });
+  });
+
+  describe("address formatting", () => {
+    it("auto-removes whitespace", () => {
+      const { result } = renderHookWithDefaults();
+
+      act(() => {
+        result.current.handleAddressChange(" G A A Z I ");
+      });
+
+      expect(result.current.address).toBe("GAAZI");
+    });
+
+    it("auto-uppercases", () => {
+      const { result } = renderHookWithDefaults();
+
+      act(() => {
+        result.current.handleAddressChange("gaazi4tcr3ty5ojhctjc2a4qsy6cjwjh5iajtgkin2er7lbnvkoccwn7");
+      });
+
+      expect(result.current.address).toBe(VALID_ADDRESS);
+    });
+  });
+
+  describe("reset", () => {
+    it("clears all state back to idle", async () => {
+      mockLoadAccount.mockResolvedValueOnce({ account_id: VALID_ADDRESS });
+
+      const { result } = renderHookWithDefaults();
+
+      act(() => {
+        result.current.handleAddressChange(VALID_ADDRESS);
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(50);
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(result.current.isValid).toBe(true);
+
+      act(() => {
+        result.current.reset();
+      });
+
+      expect(result.current.address).toBe("");
+      expect(result.current.validationState).toBe("idle");
+      expect(result.current.isValid).toBe(false);
+      expect(result.current.errorMessage).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit tests for the `useStellarAddressValidation` hook covering the three manual address entry scenarios defined in the acceptance criteria.

Closes #284

## Changes

- **New:** `src/hooks/__tests__/useStellarAddressValidation.test.tsx` — 13 tests using `@testing-library/react` (`renderHook`)
- **Added devDeps:** `@testing-library/react`, `jest-environment-jsdom`

## Acceptance Criteria Coverage

| Criteria | Tests | Count |
|----------|-------|-------|
| Empty submit shows required error | Hook returns `idle` state and `isValid: false` for empty/whitespace input | 3 |
| Invalid checksum blocks navigation | Hook returns `invalid-format` state for bad checksum, wrong length, and wrong prefix; Horizon `loadAccount` is never called | 4 |
| Valid address stores trimmed value and routes to loading | Hook transitions to `valid` after format + network check, strips whitespace, uppercases, and calls Horizon | 3 |

Additional coverage: address formatting (2), reset behavior (1).

## Notes

- Tests mock `stellar-sdk` (`StrKey` + `Horizon.Server`) and `src/config` (`RPC_ENDPOINTS`) to isolate hook behavior from external dependencies
- The connect page (`app/[locale]/connect/page.tsx`) has missing import statements for `useWrapStore`, `useSound`, etc., preventing full component-level tests — this targets the hook directly as the core validation logic

## Test Plan

```bash
npm test -- --testPathPattern=useStellarAddressValidation