### PR TITLE
fix: address share card, loading flow, and demo mode issues (#216-#219)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,19 @@ In Web3, your on-chain history is your resume, your identity, and your reputatio
 4.  **Persona:** Based on your specific behavior, you get assigned a fun archetype (e.g., *"The Soroban Architect," "The DeFi Patron," "The Diamond Hand"*).
 5.  **Share:** Generate a beautiful, branded image card ready for one-click sharing to X (Twitter), Farcaster, etc.
 
+### 🧪 Demo Mode
+
+The **"try demo mode"** link on `/connect` walks through the full experience without a
+wallet. Demo mode is **mock-only**:
+
+- It uses the fixture address in [`app/data/demoAccount.ts`](app/data/demoAccount.ts) — a
+  real, checksum-valid Stellar public key, so address validation behaves normally.
+- Entering demo mode sets a session flag (`markDemoMode()`). The loading screen checks
+  `isDemoMode()` and serves generated wrap data, so **demo mode never queries Horizon or
+  the indexer**.
+- The flag is cleared whenever `/connect` mounts, so a subsequent real wallet connection
+  or manually entered address always runs against live data.
+
 ---
 
 ## 🏗️ Architecture Diagram

--- a/app/[locale]/connect/page.tsx
+++ b/app/[locale]/connect/page.tsx
@@ -2,6 +2,11 @@
 
 import { useState, useRef, useEffect, KeyboardEvent } from "react";
 import { useRouter } from "next/navigation";
+import {
+  DEMO_STELLAR_ADDRESS,
+  markDemoMode,
+  clearDemoMode,
+} from "@/app/data/demoAccount";
 
 export default function ConnectPage() {
   const router = useRouter();
@@ -32,6 +37,9 @@ export default function ConnectPage() {
 
   // Load last-used address from localStorage on mount
   useEffect(() => {
+    // Returning to /connect always leaves demo mode; handleDemoMode re-arms it.
+    clearDemoMode();
+
     const saved = localStorage.getItem("lastUsedStellarAddress");
     if (saved) {
       setLastUsedAddress(saved);
@@ -247,10 +255,11 @@ export default function ConnectPage() {
       return;
     }
 
-    const demoAddress = "GDEMOADDRESSFORSTELLARWRAPDEMOPURPOSES12345678";
-    handleRawAddressChange(demoAddress);
+    // Demo mode is mock-only; the flag makes the loading screen skip Horizon.
+    markDemoMode();
+    handleRawAddressChange(DEMO_STELLAR_ADDRESS);
     setTimeout(() => {
-      setAddress(demoAddress);
+      setAddress(DEMO_STELLAR_ADDRESS);
       setStatus("loading");
       playSound(SOUND_NAMES.SLIDE_WHOOSH);
       router.push("/loading");

--- a/app/[locale]/share/SharePageClient.tsx
+++ b/app/[locale]/share/SharePageClient.tsx
@@ -4,7 +4,6 @@ import React, { useEffect, useRef, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { ExternalLink, Share2 } from "lucide-react";
 import { mockData } from "@/app/data/mockData";
-import { GOLDEN_USER } from "@/src/data/mockData";
 import { ProgressIndicator } from "@/app/components/ProgressIndicator";
 import { MuteToggle } from "../components/MuteToggle";
 import { ShareCard } from "../components/ShareCard";
@@ -44,6 +43,16 @@ export default function SharePageClient() {
   const persona = result?.persona ?? mockData.persona;
   const topVibe = result?.vibes[0]?.label ?? mockData.vibes[0].label;
   const vibePercentage = result?.vibes[0]?.percentage ?? mockData.vibes[0].percentage;
+
+  // The off-screen export card must render the same data as the on-screen card.
+  // archetypeImage is left undefined so the card keeps its deterministic
+  // persona-derived fallback (e.g. "The Wizard" -> /archetypes/wizard.png).
+  const shareImageData = {
+    username,
+    transactions,
+    persona,
+    vibes: result?.vibes ?? mockData.vibes,
+  };
 
   const stellarExpertUrl = walletAddress
     ? network === "testnet"
@@ -124,9 +133,9 @@ export default function SharePageClient() {
         style={{ left: "-9999px", top: 0 }}
       >
         {cardFormat === "stories" ? (
-          <ShareImageCardStories themeColor={themeColor} archetypeImage={GOLDEN_USER.archetype.image} shareUrl={shareUrl} />
+          <ShareImageCardStories themeColor={themeColor} data={shareImageData} shareUrl={shareUrl} />
         ) : (
-          <ShareImageCard themeColor={themeColor} archetypeImage={GOLDEN_USER.archetype.image} shareUrl={shareUrl} />
+          <ShareImageCard themeColor={themeColor} data={shareImageData} shareUrl={shareUrl} />
         )}
       </div>
 

--- a/app/components/ShareImageCard.tsx
+++ b/app/components/ShareImageCard.tsx
@@ -22,11 +22,18 @@ interface ShareImageCardProps {
   themeColor: string;
   archetypeImage?: string | null; // e.g. '/archetypes/wizard.png'; null hides the image fallback.
   data?: ShareImageCardData;
-  archetypeImage?: string;
   shareUrl?: string;
 }
 
+export function ShareImageCard({
+  themeColor,
+  archetypeImage,
+  data,
+  shareUrl,
+}: ShareImageCardProps) {
+  const { persona, transactions, username, vibes = [] } = data ?? mockData;
   const topVibe = vibes[0];
+  // Derive image from persona name if not explicitly provided: "The Wizard" -> /archetypes/wizard.png
   const resolvedArchetypeImage =
     archetypeImage === undefined
       ? `/archetypes/${persona.toLowerCase().replace(/^the\s+/, "").replace(/\s+/g, "-")}.png`

--- a/app/components/ShareImageCardStories.tsx
+++ b/app/components/ShareImageCardStories.tsx
@@ -3,14 +3,27 @@
 import Image from "next/image";
 import { mockData } from "../data/mockData";
 
+interface ShareImageCardStoriesVibe {
+  percentage: number;
+  label: string;
+}
+
+interface ShareImageCardStoriesData {
+  username: string;
+  transactions: number;
+  persona: string;
+  vibes?: ShareImageCardStoriesVibe[];
+}
+
 interface ShareImageCardStoriesProps {
   themeColor: string;
   archetypeImage?: string;
+  data?: ShareImageCardStoriesData;
   shareUrl?: string;
 }
 
-export function ShareImageCardStories({ themeColor, archetypeImage, shareUrl }: ShareImageCardStoriesProps) {
-  const { persona, transactions, username, vibes } = mockData;
+export function ShareImageCardStories({ themeColor, archetypeImage, data, shareUrl }: ShareImageCardStoriesProps) {
+  const { persona, transactions, username, vibes = [] } = data ?? mockData;
   const topVibe = vibes[0];
   const topThreeVibes = vibes.slice(0, 3);
   const resolvedArchetypeImage =

--- a/app/data/demoAccount.ts
+++ b/app/data/demoAccount.ts
@@ -1,0 +1,30 @@
+/**
+ * Demo mode fixture.
+ *
+ * The previous placeholder ("GDEMOADDRESS...") was only 46 characters and had no
+ * valid strkey checksum, so it failed address validation and, if it ever reached
+ * the indexer, would have produced a bogus Horizon request. This is the same
+ * valid Ed25519 public key already used as `validGAddr` across the test suite.
+ *
+ * Demo mode is mock-only: the loading screen detects it via `isDemoMode()` and
+ * serves generated wrap data instead of querying Horizon.
+ */
+export const DEMO_STELLAR_ADDRESS =
+  "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7";
+
+const DEMO_MODE_STORAGE_KEY = "stellarWrap:demoMode";
+
+export function markDemoMode(): void {
+  if (typeof window === "undefined") return;
+  window.sessionStorage.setItem(DEMO_MODE_STORAGE_KEY, "true");
+}
+
+export function isDemoMode(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.sessionStorage.getItem(DEMO_MODE_STORAGE_KEY) === "true";
+}
+
+export function clearDemoMode(): void {
+  if (typeof window === "undefined") return;
+  window.sessionStorage.removeItem(DEMO_MODE_STORAGE_KEY);
+}

--- a/app/loading/page.tsx
+++ b/app/loading/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { motion } from "motion/react";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { Home, ChevronRight } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
@@ -15,6 +15,11 @@ import { useSound } from "../hooks/useSound";
 import { SOUND_NAMES } from "../utils/soundManager";
 import { indexAccount } from "../services/indexerService";
 import { IndexerEventEmitter } from "../utils/indexerEventEmitter";
+import { isDemoMode } from "../data/demoAccount";
+import {
+  shouldNavigateToPersona,
+  toIndexerErrorMessage,
+} from "../utils/indexerFailure";
 
 export default function LoadingScreen() {
   const router = useRouter();
@@ -27,6 +32,11 @@ export default function LoadingScreen() {
     playSound(SOUND_NAMES.SLIDE_WHOOSH);
     router.push("/persona");
   }, [router, playSound]);
+
+  // Held in a ref so the indexing effect below depends only on the inputs that
+  // should actually re-trigger indexing, not on callback identity.
+  const handleCompleteRef = useRef(handleComplete);
+  handleCompleteRef.current = handleComplete;
 
   const handleCancel = useCallback(() => {
     abortIndexingRequests();
@@ -122,13 +132,22 @@ export default function LoadingScreen() {
         setError(null);
         setCacheMeta(null);
 
-        // NOTE: Do NOT call loadIndexingState() here - it will overwrite isLoading: true
-        // The startIndexing() call above already set isLoading, which is what matters
+        // NOTE: loadIndexingState() is deliberately neither called nor listed as a
+        // dependency of this effect - it would overwrite the isLoading: true that
+        // startIndexing() just set above, which is the state this screen renders from.
 
         // Call real indexer service - will emit step progress events
         let result: WrapResult | null = null;
 
-        if (address) {
+        if (isDemoMode()) {
+          // Demo mode is mock-only: never hit Horizon for the demo fixture address.
+          await emitProgressThroughSteps();
+          result = mapIndexerResultToWrapResult({
+            totalTransactions: 42,
+            dapps: [],
+            largestTransaction: { amount: 1000, assetCode: "XLM" },
+          });
+        } else if (address) {
           if (!navigator.onLine) {
             const cached = await getMostRecentCachedData();
             if (cached) {
@@ -162,7 +181,7 @@ export default function LoadingScreen() {
 
         if (!isMounted || abortSignal.aborted || useWrapStore.getState().isCancelled) return;
 
-        if (!result) {
+        if (!shouldNavigateToPersona(result)) {
           throw new Error("No wrap data available.");
         }
 
@@ -175,26 +194,24 @@ export default function LoadingScreen() {
         // Give progress display time to be visible (minimum 1.5 seconds)
         setTimeout(() => {
           if (isMounted) {
-            handleComplete();
+            handleCompleteRef.current();
           }
         }, 1500);
       } catch (error: unknown) {
         if (isAbortError(error) || !isMounted) return;
+
+        const message = toIndexerErrorMessage(error);
+
         setStatus("error");
-        if (error instanceof Error) {
-          setError(error.message);
-        } else {
-          setError("Failed to load wrap data");
-        }
-        if (!navigator.onLine) {
-          return;
-        }
-        // Fallback: still navigate so user isn’t stuck
-        setTimeout(() => {
-          if (isMounted) {
-            handleComplete();
-          }
-        }, 1200);
+        setError(message);
+
+        // Keep the user on the actionable error/retry UI. We reach this branch only
+        // when neither real result data nor the mock fallback produced a result, so
+        // navigating to /persona would render an empty wrap and hide the real
+        // indexer failure. StepProgressDisplay renders the retry affordance from
+        // indexingError, so surface the failure there too.
+        const { currentStep, setIndexingError } = useWrapStore.getState();
+        setIndexingError(currentStep ?? "initializing", message, true);
       }
     };
 
@@ -206,18 +223,10 @@ export default function LoadingScreen() {
       clearIndexingAbortScope();
       IndexerEventEmitter.getInstance().reset();
     };
-  }, [
-    address,
-    period,
-    network,
-    setError,
-    setResult,
-    setStatus,
-    setCacheMeta,
-    handleComplete,
-    startIndexing,
-    completeIndexing,
-  ]);
+    // Only the indexing inputs belong here. Zustand actions are stable, and
+    // handleComplete is read through a ref, so this effect runs once per
+    // address/period/network rather than restarting on every render.
+  }, [address, period, network]);
 
   const starConfigs = useMemo(
     () =>

--- a/app/utils/__tests__/indexerFailure.test.ts
+++ b/app/utils/__tests__/indexerFailure.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Regression tests for fatal indexer failures on the loading screen (#218).
+ *
+ * The bug: the loading screen caught an unrecoverable indexer error, set the
+ * error state, and then navigated to /persona anyway after a short delay. That
+ * rendered an empty wrap and hid the real failure, leaving the user with no
+ * retry affordance.
+ */
+
+import {
+  shouldNavigateToPersona,
+  toIndexerErrorMessage,
+} from "../indexerFailure";
+
+describe("shouldNavigateToPersona", () => {
+  it("does not navigate when a fatal failure left no result", () => {
+    // Fatal indexer failure: nothing was produced, so the user must stay on the
+    // error/retry UI rather than being pushed to an empty persona screen.
+    expect(shouldNavigateToPersona(null)).toBe(false);
+    expect(shouldNavigateToPersona(undefined)).toBe(false);
+  });
+
+  it("navigates when real indexer result data is available", () => {
+    const result = { username: "stellar_legend", totalTransactions: 420 };
+
+    expect(shouldNavigateToPersona(result)).toBe(true);
+  });
+
+  it("navigates when the mock/cached fallback produced a result", () => {
+    const fallback = { username: "demo", totalTransactions: 42 };
+
+    expect(shouldNavigateToPersona(fallback)).toBe(true);
+  });
+});
+
+describe("toIndexerErrorMessage", () => {
+  it("surfaces the underlying indexer error message", () => {
+    expect(toIndexerErrorMessage(new Error("Horizon request timed out"))).toBe(
+      "Horizon request timed out",
+    );
+  });
+
+  it("falls back to a generic message for non-Error throws", () => {
+    expect(toIndexerErrorMessage("boom")).toBe("Failed to load wrap data");
+    expect(toIndexerErrorMessage(new Error(""))).toBe(
+      "Failed to load wrap data",
+    );
+  });
+});

--- a/app/utils/indexerFailure.ts
+++ b/app/utils/indexerFailure.ts
@@ -1,0 +1,31 @@
+/**
+ * Helpers for the loading screen's terminal-failure handling.
+ *
+ * Extracted from `app/loading/page.tsx` so the navigation decision can be unit
+ * tested without rendering the page (the suite runs in a `node` environment with
+ * no DOM). Previously the loading screen caught a fatal indexer error, set the
+ * error state, and then navigated to /persona anyway - which rendered an empty
+ * wrap and hid the real failure from the user.
+ */
+
+const DEFAULT_INDEXER_ERROR_MESSAGE = "Failed to load wrap data";
+
+/**
+ * Navigate onward only when we actually have something to show: either real
+ * indexer output or the mock/cached fallback result. A null result means the
+ * failure is unrecoverable for this attempt and the user must stay on the
+ * error/retry UI.
+ */
+export function shouldNavigateToPersona<T>(
+  result: T | null | undefined,
+): result is T {
+  return result !== null && result !== undefined;
+}
+
+/** Normalizes an unknown thrown value into a user-facing message. */
+export function toIndexerErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  return DEFAULT_INDEXER_ERROR_MESSAGE;
+}


### PR DESCRIPTION
fix(share): derive ShareImageCard data from current wrap result (#216)
- Pass the live wrap result (username, transactions, persona, vibes) to the off-screen export cards instead of GOLDEN_USER/static mock data, so the exported image matches the on-screen share card.
- Add the same `data` prop to ShareImageCardStories.
- Leave archetypeImage undefined so the deterministic persona-derived fallback is used when result data is missing.
- Restore the ShareImageCard component signature and drop the duplicated `archetypeImage` prop declaration.

fix(loading): remove unused loadIndexingState dependency from effect (#217)
- Narrow the indexing effect deps to the actual inputs (address, period, network); Zustand actions are stable and handleComplete is now read through a ref, so the effect no longer restarts on unrelated re-renders.
- Clarify the stale NOTE explaining why loadIndexingState is neither called nor depended on here.

fix(loading): show error state instead of always navigating after fatal failure (#218)
- Stop navigating to /persona after an unrecoverable indexer failure; users stay on the actionable error/retry UI.
- Surface the failure via setIndexingError so StepProgressDisplay renders the retry affordance.
- Navigation now happens only when real or mock/cached fallback result data exists.
- Extract shouldNavigateToPersona/toIndexerErrorMessage into app/utils/indexerFailure.ts and add regression tests.

fix(connect): replace invalid demo Stellar address (#219)
- Replace the 46-character, checksum-invalid placeholder with the repo's existing valid public key fixture.
- Mark demo mode as mock-only via a session flag so the loading screen serves generated data and never queries Horizon; the flag is cleared on /connect mount.
- Document demo mode behaviour in the README.
closes #216
closes #217
closes #218
closes #219