### PR TITLE
308 dependency audit workflow closes #308

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,38 @@
+name: Dependency Audit
+
+on:
+  pull_request:
+    branches:
+      - "**"
+    paths:
+      - "package.json"
+      - "pnpm-lock.yaml"
+  schedule:
+    # Every Monday at 09:00 UTC
+    - cron: "0 9 * * 1"
+  workflow_dispatch: {}
+
+jobs:
+  audit:
+    name: pnpm audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run dependency audit
+        run: pnpm audit --audit-level=high

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,2 +1,31 @@
 # Contributing to Stellar Wrap
 
+## Handling dependency advisory exceptions
+
+Our CI runs `pnpm audit` on every PR that touches `package.json` or
+`pnpm-lock.yaml`, plus a weekly scheduled scan.
+
+If an advisory has no available fix (no patched version exists) and a
+maintainer has assessed it as not exploitable in our usage, it can be
+suppressed via `pnpm.auditConfig.ignoreCves` in `package.json`:
+
+​```json
+{
+  "pnpm": {
+    "auditConfig": {
+      "ignoreCves": ["CVE-2024-XXXXX"]
+    }
+  }
+}
+​```
+
+Before adding an entry:
+1. Confirm no patched version is available (`pnpm audit` will say so).
+2. Document *why* it's safe to ignore in the PR description that adds the
+   exception (e.g. "only affects a build-time-only dependency, never
+   shipped to production").
+3. Revisit ignored CVEs periodically — remove the entry once a fix ships.
+
+Note: this project pins `pnpm@10.25.0`. If upgraded to pnpm v11+, this
+field is renamed to `pnpm.auditConfig.ignoreGhsas` and uses GitHub
+Advisory IDs (GHSA-xxxx-xxxx-xxxx) instead of CVE numbers.

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "next-version",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "pnpm@9.0.0",
+  "packageManager": "pnpm@10.25.0",
   "engines": {
     "node": ">=18.0.0",
-    "pnpm": ">=9.0.0"
+    "pnpm": ">=10.0.0"
   },
   "scripts": {
     "dev": "next dev",
@@ -59,6 +59,5 @@
     "ts-jest": "^29.4.6",
     "typescript": "^5",
     "vitest": "^4.1.9"
-  },
-  "packageManager": "pnpm@10.25.0"
+  }
 }


### PR DESCRIPTION
adds a dependency audit CI workflow. Note: implemented with pnpm audit (not Yarn as the issue mentioned), since the repo's package.json and ci.yml confirm this project actually uses pnpm.

What was added:

.github/workflows/dependency-audit.yml — runs pnpm audit --audit-level=high on PRs touching package.json/pnpm-lock.yaml, weekly on schedule, and manually via workflow_dispatch
Fixed a duplicate packageManager key in package.json (pinned to pnpm@10.25.0)
Added a "Handling advisory exceptions" section to CONTRIBUTING.md

closes #308