### PR TITLE
fix(contract): add timeout UI for long Soroban confirmation polling

### DIFF
--- a/app/components/ShareCard.tsx
+++ b/app/components/ShareCard.tsx
@@ -1,5 +1,5 @@
 import { motion } from "motion/react";
-import { Share2, Download, Twitter, Loader2, Sparkles, AlertCircle, Film, ImagePlay } from "lucide-react";
+import { Share2, Download, Twitter, Loader2, Sparkles, AlertCircle, Film, ImagePlay, ExternalLink } from "lucide-react";
 import { useState, RefObject, useEffect } from "react";
 import { downloadShareImage } from "../utils/imageExport";
 import { useWrapStore } from "@/app/store/wrapStore";
@@ -36,7 +36,7 @@ export function ShareCard({
   const { playSound } = useSound();
   const isOnline = useOnlineStatus();
   
-  const { transactionState, transactionHash, transactionError, resetTransaction } = useTransactionStore();
+  const { transactionState, transactionHash, transactionError, resetTransaction, confirmingAttempt, confirmingTimedOut, setConfirmingAttempt, setConfirmingTimedOut } = useTransactionStore();
 
   const isMinting = [
     "building",
@@ -173,17 +173,42 @@ export function ShareCard({
 
     if (transactionState === "failed" || transactionState === "confirmed") {
       resetTransaction();
+      setConfirmingAttempt(null);
+      setConfirmingTimedOut(false);
     }
 
     // Transaction state observer
     const observer = (state: string, data?: unknown) => {
       console.log("Transaction state:", state, data);
-      
+
+      // Track per-tick confirming progress
+      if (
+        state === 'submitted' &&
+        data &&
+        typeof data === 'object' &&
+        'confirming' in data
+      ) {
+        const d = data as { attempt: number; maxAttempts: number };
+        setConfirmingAttempt(d.attempt);
+        return; // don't propagate as a state change — still "submitted" in the store
+      }
+
+      // Detect structured timeout payload
+      if (
+        state === 'failed' &&
+        data &&
+        typeof data === 'object' &&
+        'code' in data &&
+        (data as { code: string }).code === 'CONFIRMATION_TIMEOUT'
+      ) {
+        setConfirmingTimedOut(true);
+        setConfirmingAttempt(null);
+      }
+
       // Handle simulation results
       if (state === 'simulating' && data && typeof data === 'object' && 'simulation' in data) {
         const simulation = (data as { simulation: { success?: boolean; estimatedFee?: number } }).simulation;
         if (simulation?.success && simulation?.estimatedFee) {
-          // Show simulation success with fee estimate
           toast.info("Transaction simulation successful", {
             description: `Estimated fee: ${simulation.estimatedFee.toFixed(7)} XLM`,
           });
@@ -213,13 +238,17 @@ export function ShareCard({
       case "signing":
         return "Awaiting wallet signature...";
       case "submitting":
-        return "Submitting transaction...";
+        return confirmingAttempt !== null
+          ? `Confirming… attempt ${confirmingAttempt} / 60`
+          : "Submitting transaction...";
       case "confirming":
-        return "Confirming transaction...";
+        return confirmingAttempt !== null
+          ? `Confirming… attempt ${confirmingAttempt} / 60`
+          : "Confirming transaction...";
       case "confirmed":
         return "Minted!";
       case "failed":
-        return "Retry Mint";
+        return confirmingTimedOut ? "Retry Mint" : "Retry Mint";
       default:
         return isOnline ? "Mint My Wrap" : "Mint unavailable offline";
     }
@@ -510,6 +539,63 @@ export function ShareCard({
                 </div>
               </motion.div>
             </div>
+
+          {/* Polling progress bar — shown while awaiting confirmation */}
+          {confirmingAttempt !== null && !confirmingTimedOut && (
+            <motion.div
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              className="w-full mt-6 rounded-xl border border-white/10 bg-black/40 p-4"
+              aria-live="polite"
+              aria-label={`Confirming transaction, attempt ${confirmingAttempt} of 60`}
+            >
+              <div className="flex justify-between text-xs text-white/60 mb-2">
+                <span>Waiting for confirmation on-chain…</span>
+                <span>{confirmingAttempt} / 60</span>
+              </div>
+              <div className="h-1.5 bg-white/10 rounded-full overflow-hidden">
+                <motion.div
+                  className="h-full rounded-full"
+                  style={{ backgroundColor: "var(--color-theme-primary)" }}
+                  animate={{ width: `${Math.round((confirmingAttempt / 60) * 100)}%` }}
+                  transition={{ duration: 0.4, ease: "easeOut" }}
+                />
+              </div>
+            </motion.div>
+          )}
+
+          {/* Timeout banner — shown when confirmation window expired */}
+          {confirmingTimedOut && (
+            <motion.div
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              className="w-full mt-6 rounded-xl border border-amber-500/30 bg-amber-500/10 p-4 space-y-3"
+              role="alert"
+            >
+              <div className="flex items-start gap-3">
+                <AlertCircle className="w-5 h-5 text-amber-400 shrink-0 mt-0.5" aria-hidden="true" />
+                <div>
+                  <p className="text-sm font-bold text-amber-200">
+                    Confirmation is taking longer than expected
+                  </p>
+                  <p className="text-xs text-amber-200/70 mt-1">
+                    Your transaction may still go through — check the explorer before retrying to avoid a duplicate.
+                  </p>
+                </div>
+              </div>
+              {transactionHash && (
+                <a
+                  href={`https://stellar.expert/explorer/${network === "mainnet" ? "public" : "testnet"}/tx/${transactionHash}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 text-xs font-bold text-amber-300 hover:text-amber-100 transition-colors"
+                >
+                  <ExternalLink className="w-3.5 h-3.5" aria-hidden="true" />
+                  View transaction on Stellar.expert
+                </a>
+              )}
+            </motion.div>
+          )}
 
           {/* Mint Button below the card */}
           <motion.button

--- a/app/store/transactionStore.ts
+++ b/app/store/transactionStore.ts
@@ -18,10 +18,16 @@ interface TransactionStoreState {
   transactionState: TransactionState;
   transactionHash: string | null;
   transactionError: string | null;
+  /** Current polling attempt index (1-based) while in the confirming state, null otherwise */
+  confirmingAttempt: number | null;
+  /** True when confirmation polling exhausted its timeout window */
+  confirmingTimedOut: boolean;
   // actions
   setTransactionState: (state: TransactionState) => void;
   setTransactionHash: (hash: string | null) => void;
   setTransactionError: (error: string | null) => void;
+  setConfirmingAttempt: (attempt: number | null) => void;
+  setConfirmingTimedOut: (timedOut: boolean) => void;
   resetTransaction: () => void;
 }
 
@@ -31,14 +37,20 @@ export const useTransactionStore = create<TransactionStoreState>()(
       transactionState: "idle",
       transactionHash: null,
       transactionError: null,
+      confirmingAttempt: null,
+      confirmingTimedOut: false,
       setTransactionState: (state) => set({ transactionState: state }),
       setTransactionHash: (hash) => set({ transactionHash: hash }),
       setTransactionError: (error) => set({ transactionError: error }),
+      setConfirmingAttempt: (attempt) => set({ confirmingAttempt: attempt }),
+      setConfirmingTimedOut: (timedOut) => set({ confirmingTimedOut: timedOut }),
       resetTransaction: () =>
         set({
           transactionState: "idle",
           transactionHash: null,
           transactionError: null,
+          confirmingAttempt: null,
+          confirmingTimedOut: false,
         }),
     }),
     {

--- a/src/services/contractBridge.ts
+++ b/src/services/contractBridge.ts
@@ -141,9 +141,28 @@ async function waitForConfirmation(
   let attempts = 0;
 
   while (attempts < MAX_CONFIRMATION_ATTEMPTS) {
-    if (Date.now() - startTime > TRANSACTION_TIMEOUT) {
+    const elapsedMs = Date.now() - startTime;
+
+    if (elapsedMs > TRANSACTION_TIMEOUT) {
+      // Emit a structured timeout payload so the UI can show actionable copy
+      // without resubmitting automatically.
+      emitState(observer, 'failed', {
+        code: 'CONFIRMATION_TIMEOUT',
+        transactionHash,
+        elapsedMs,
+        attempts,
+      });
       throw new Error('Transaction confirmation timeout');
     }
+
+    // Emit per-tick confirming progress (1-based attempt for display)
+    emitState(observer, 'submitted', {
+      confirming: true,
+      attempt: attempts + 1,
+      maxAttempts: MAX_CONFIRMATION_ATTEMPTS,
+      elapsedMs,
+      transactionHash,
+    });
 
     try {
       const response = await server.getTransaction(transactionHash);
@@ -164,6 +183,9 @@ async function waitForConfirmation(
       if (error instanceof Error && error.message.includes('Transaction failed')) {
         throw error;
       }
+      if (error instanceof Error && error.message.includes('confirmation timeout')) {
+        throw error;
+      }
       console.warn(`Polling attempt ${attempts + 1} failed:`, error);
     }
 
@@ -171,6 +193,13 @@ async function waitForConfirmation(
     await new Promise((resolve) => setTimeout(resolve, CONFIRMATION_POLL_INTERVAL));
   }
 
+  // Max attempts exhausted — treat the same as a timeout
+  emitState(observer, 'failed', {
+    code: 'CONFIRMATION_TIMEOUT',
+    transactionHash,
+    elapsedMs: Date.now() - startTime,
+    attempts,
+  });
   throw new Error(
     `Transaction not confirmed after ${MAX_CONFIRMATION_ATTEMPTS} attempts`,
   );


### PR DESCRIPTION
## Summary

`waitForConfirmation` polls Soroban RPC for up to 2 minutes (60 attempts × 2 s) with no visibility into its progress. Users staring at a static `submitted` state had no way to distinguish a slow network from a hung UI, and a silent timeout left them without any retry guidance.

This PR surfaces polling progress in the UI, shows a descriptive timeout message when the 2-minute window expires, and gates any retry on an explicit user action — no automatic resubmission.

## Changes

### `app/store/transactionStore.ts`
- Add `confirmingAttempt: number | null` — tracks the current poll tick (1-based) while waiting for on-chain confirmation; `null` otherwise.
- Add `confirmingTimedOut: boolean` — flipped to `true` when the confirmation window expires.
- Add `setConfirmingAttempt` and `setConfirmingTimedOut` actions.
- Include both fields in `resetTransaction` so retries always start clean.

### `src/services/contractBridge.ts`
- Emit a per-tick `{ confirming: true, attempt, maxAttempts, elapsedMs, transactionHash }` payload on every poll iteration (via the `submitted` observer event) so the UI can drive a live counter without changing the external state machine.
- On timeout (wall-clock **or** max-attempts exhausted), emit a structured `{ code: 'CONFIRMATION_TIMEOUT', transactionHash, elapsedMs, attempts }` payload instead of a bare error string — giving the UI a reliable discriminator to show actionable copy.

### `app/components/ShareCard.tsx`
- Subscribe to `confirmingAttempt` and `confirmingTimedOut` from the transaction store.
- Observer forwards per-tick payloads → `setConfirmingAttempt`; timeout payloads → `setConfirmingTimedOut`.
- `getMintButtonText` shows **"Confirming… attempt N / 60"** during polling.
- Animated progress bar renders below the share card while polling is active (`aria-live` for screen readers).
- Amber timeout banner with a **"View transaction on Stellar.expert"** link appears on timeout — the user can verify before retrying.
- Retry button resets all confirming state but does **not** resubmit the transaction automatically.

## Acceptance criteria

| Criterion | Status |
|-----------|--------|
| Surface polling state in the UI | ✅ Live `attempt N / 60` counter + animated progress bar |
| Show actionable timeout message after confirmation timeout | ✅ Amber banner with explorer link on `confirmingTimedOut` |
| Do not resubmit transactions automatically without user action | ✅ Retry only resets store state; resubmission requires an explicit click |

Closes #231
