### PR TITLE
fix(wallet): validate connected wallet network before indexing

### DIFF
--- a/app/[locale]/connect/page.tsx
+++ b/app/[locale]/connect/page.tsx
@@ -2,6 +2,24 @@
 
 import { useState, useRef, useEffect, KeyboardEvent } from "react";
 import { useRouter } from "next/navigation";
+import { motion, AnimatePresence } from "framer-motion";
+import { ArrowLeft, Wallet, Copy, CheckCircle, XCircle, ChevronRight, QrCode } from "lucide-react";
+import { useWrapStore } from "@/app/store/wrapStore";
+import { useTransactionStore } from "@/app/store/transactionStore";
+import { useMultiTimeframeStore } from "@/app/store/multiTimeframeStore";
+import { useSound, SOUND_NAMES } from "@/app/hooks/useSound";
+import { useOnlineStatus } from "@/app/hooks/useOnlineStatus";
+import { useStellarAddressValidation } from "@/app/hooks/useStellarAddressValidation";
+import { ProgressIndicator } from "@/app/components/ProgressIndicator";
+import { MuteToggle } from "@/app/[locale]/components/MuteToggle";
+import {
+  connectFreighter,
+  connectAlbedo,
+  connectXBull,
+  isXBullInstalled,
+  NetworkMismatchError,
+} from "@/app/utils/walletConnect";
+import { connectWalletConnect } from "@/app/utils/walletKit";
 
 export default function ConnectPage() {
   const router = useRouter();
@@ -21,6 +39,15 @@ export default function ConnectPage() {
 
   const [isConnecting, setIsConnecting] = useState(false);
   const [localError, setLocalError] = useState<string | null>(null);
+  /**
+   * When set, the user's Freighter wallet is on a different network than the
+   * app expects. The object holds both sides so the UI can show an actionable
+   * switch-network prompt.
+   */
+  const [networkMismatch, setNetworkMismatch] = useState<{
+    expected: string;
+    actual: string;
+  } | null>(null);
 
   // Refs for focus management
   const mainContentRef = useRef<HTMLDivElement>(null);
@@ -52,6 +79,7 @@ export default function ConnectPage() {
 
     setIsConnecting(true);
     setLocalError(null);
+    setNetworkMismatch(null);
     setStatus("loading");
     // Reset all stores before connecting
     reset();
@@ -66,11 +94,17 @@ export default function ConnectPage() {
       playSound(SOUND_NAMES.SLIDE_WHOOSH);
       await fetchAccountPreview(publicKey);
     } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : "Failed to connect wallet";
-      setError(errorMessage);
-      setLocalError(errorMessage);
-      setStatus("error");
+      if (error instanceof NetworkMismatchError) {
+        // Surface a targeted switch-network prompt instead of a generic error
+        setNetworkMismatch({ expected: error.expected, actual: error.actual });
+        setStatus("idle");
+      } else {
+        const msg =
+          error instanceof Error ? error.message : "Failed to connect wallet";
+        setError(msg);
+        setLocalError(msg);
+        setStatus("error");
+      }
     } finally {
       setIsConnecting(false);
     }
@@ -720,6 +754,43 @@ export default function ConnectPage() {
                   className="mb-6 p-4 bg-red-500/10 border-2 border-red-500/50 rounded-xl text-red-400 text-sm text-center font-medium"
                 >
                   ⚠️ {localError}
+                </motion.div>
+              )}
+              {/* ── Network mismatch prompt ───────────────────────────── */}
+              {networkMismatch && (
+                <motion.div
+                  data-testid="network-mismatch-prompt"
+                  initial={{ opacity: 0, y: -10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -10 }}
+                  className="mb-6 p-4 bg-yellow-500/10 border-2 border-yellow-500/50 rounded-xl text-yellow-300 text-sm font-medium"
+                >
+                  <p className="font-bold mb-1">⚠️ Wallet network mismatch</p>
+                  <p className="text-yellow-400/80 text-xs mb-3">
+                    Freighter is connected to{" "}
+                    <span className="font-bold text-yellow-300">
+                      {networkMismatch.actual}
+                    </span>
+                    , but this app is set to{" "}
+                    <span className="font-bold text-yellow-300">
+                      {networkMismatch.expected}
+                    </span>
+                    . Please switch your Freighter wallet to{" "}
+                    <span className="font-bold text-yellow-300">
+                      {networkMismatch.expected}
+                    </span>{" "}
+                    and try again.
+                  </p>
+                  <button
+                    data-testid="network-mismatch-retry"
+                    onClick={() => {
+                      setNetworkMismatch(null);
+                      handleFreighterConnect();
+                    }}
+                    className="w-full px-4 py-2 rounded-lg bg-yellow-500/20 border border-yellow-500/50 text-yellow-200 font-bold text-xs hover:bg-yellow-500/30 transition-colors focus:outline-none focus:ring-2 focus:ring-yellow-400"
+                  >
+                    I&apos;ve switched — try again
+                  </button>
                 </motion.div>
               )}
               {!isOnline && !localError && (

--- a/app/utils/__tests__/walletConnect.network.test.ts
+++ b/app/utils/__tests__/walletConnect.network.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Regression tests for #224 — wallet network validation before indexing.
+ *
+ * Covers:
+ * - NetworkMismatchError is thrown when Freighter is on the wrong network
+ * - connectFreighter succeeds when Freighter is on the correct network
+ * - connectFreighter succeeds when network cannot be determined (null)
+ * - getFreighterNetwork maps passphrases to the correct Network values
+ *
+ * @module walletConnect.network.test
+ */
+
+import { NETWORK_PASSPHRASES } from "@/src/config";
+import {
+  connectFreighter,
+  getFreighterNetwork,
+  NetworkMismatchError,
+} from "@/app/utils/walletConnect";
+
+// ─── Mock @stellar/freighter-api ────────────────────────────────────────────
+
+jest.mock("@stellar/freighter-api", () => ({
+  isConnected: jest.fn().mockResolvedValue({ error: null }),
+  requestAccess: jest.fn().mockResolvedValue({
+    address: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+    error: null,
+  }),
+  getAddress: jest.fn().mockResolvedValue({
+    address: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+    error: null,
+  }),
+  getNetworkDetails: jest.fn(),
+}));
+
+import { getNetworkDetails } from "@stellar/freighter-api";
+const mockGetNetworkDetails = getNetworkDetails as jest.Mock;
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+const MOCK_ADDRESS = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+
+// The jest environment is "node" (see jest.config.ts) so `window` is
+// undefined. isFreighterInstalled bails out early when window is missing.
+// Inject a minimal global so the function reaches the isConnected() call.
+beforeAll(() => {
+  if (typeof global.window === "undefined") {
+    // @ts-expect-error intentional window stub for node test env
+    global.window = {};
+  }
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  const freighterApi = jest.requireMock("@stellar/freighter-api");
+  freighterApi.isConnected.mockResolvedValue({ error: null });
+  freighterApi.requestAccess.mockResolvedValue({
+    address: MOCK_ADDRESS,
+    error: null,
+  });
+});
+
+// ─── NetworkMismatchError ────────────────────────────────────────────────────
+
+describe("NetworkMismatchError", () => {
+  it("has the correct name", () => {
+    const err = new NetworkMismatchError("testnet", "mainnet");
+    expect(err.name).toBe("NetworkMismatchError");
+  });
+
+  it("exposes expected and actual networks", () => {
+    const err = new NetworkMismatchError("testnet", "mainnet");
+    expect(err.expected).toBe("testnet");
+    expect(err.actual).toBe("mainnet");
+  });
+
+  it("is an instance of Error", () => {
+    expect(new NetworkMismatchError("mainnet", "testnet")).toBeInstanceOf(Error);
+  });
+
+  it("message contains both network names", () => {
+    const err = new NetworkMismatchError("testnet", "mainnet");
+    expect(err.message).toContain("mainnet");
+    expect(err.message).toContain("testnet");
+  });
+});
+
+// ─── getFreighterNetwork ─────────────────────────────────────────────────────
+
+describe("getFreighterNetwork", () => {
+  it("returns 'mainnet' when passphrase matches mainnet", async () => {
+    mockGetNetworkDetails.mockResolvedValue({
+      networkPassphrase: NETWORK_PASSPHRASES.mainnet,
+      network: "PUBLIC",
+      networkUrl: "https://horizon.stellar.org",
+    });
+    expect(await getFreighterNetwork()).toBe("mainnet");
+  });
+
+  it("returns 'testnet' when passphrase matches testnet", async () => {
+    mockGetNetworkDetails.mockResolvedValue({
+      networkPassphrase: NETWORK_PASSPHRASES.testnet,
+      network: "TESTNET",
+      networkUrl: "https://horizon-testnet.stellar.org",
+    });
+    expect(await getFreighterNetwork()).toBe("testnet");
+  });
+
+  it("returns null for an unknown/custom network passphrase", async () => {
+    mockGetNetworkDetails.mockResolvedValue({
+      networkPassphrase: "Custom Standalone Network ; 2024",
+      network: "STANDALONE",
+      networkUrl: "http://localhost:8000",
+    });
+    expect(await getFreighterNetwork()).toBeNull();
+  });
+
+  it("returns null when getNetworkDetails returns an error", async () => {
+    mockGetNetworkDetails.mockResolvedValue({
+      error: { message: "Not connected" },
+      networkPassphrase: "",
+      network: "",
+      networkUrl: "",
+    });
+    expect(await getFreighterNetwork()).toBeNull();
+  });
+
+  it("returns null when getNetworkDetails throws", async () => {
+    mockGetNetworkDetails.mockRejectedValue(new Error("Extension not found"));
+    expect(await getFreighterNetwork()).toBeNull();
+  });
+
+  it("handles leading/trailing whitespace in passphrase", async () => {
+    mockGetNetworkDetails.mockResolvedValue({
+      networkPassphrase: `  ${NETWORK_PASSPHRASES.testnet}  `,
+      network: "TESTNET",
+      networkUrl: "",
+    });
+    expect(await getFreighterNetwork()).toBe("testnet");
+  });
+});
+
+// ─── connectFreighter — network validation regression (#224) ─────────────────
+
+describe("connectFreighter — network mismatch regression (#224)", () => {
+  it("throws NetworkMismatchError when wallet is on mainnet but app expects testnet", async () => {
+    mockGetNetworkDetails.mockResolvedValue({
+      networkPassphrase: NETWORK_PASSPHRASES.mainnet,
+      network: "PUBLIC",
+      networkUrl: "",
+    });
+    await expect(connectFreighter("testnet")).rejects.toBeInstanceOf(NetworkMismatchError);
+  });
+
+  it("thrown NetworkMismatchError has correct expected/actual fields", async () => {
+    mockGetNetworkDetails.mockResolvedValue({
+      networkPassphrase: NETWORK_PASSPHRASES.mainnet,
+      network: "PUBLIC",
+      networkUrl: "",
+    });
+    await expect(connectFreighter("testnet")).rejects.toMatchObject({
+      expected: "testnet",
+      actual: "mainnet",
+    });
+  });
+
+  it("throws NetworkMismatchError when wallet is on testnet but app expects mainnet", async () => {
+    mockGetNetworkDetails.mockResolvedValue({
+      networkPassphrase: NETWORK_PASSPHRASES.testnet,
+      network: "TESTNET",
+      networkUrl: "",
+    });
+    await expect(connectFreighter("mainnet")).rejects.toBeInstanceOf(NetworkMismatchError);
+  });
+
+  it("resolves with the public key when wallet and app are both on testnet", async () => {
+    mockGetNetworkDetails.mockResolvedValue({
+      networkPassphrase: NETWORK_PASSPHRASES.testnet,
+      network: "TESTNET",
+      networkUrl: "",
+    });
+    await expect(connectFreighter("testnet")).resolves.toBe(MOCK_ADDRESS);
+  });
+
+  it("resolves with the public key when wallet and app are both on mainnet", async () => {
+    mockGetNetworkDetails.mockResolvedValue({
+      networkPassphrase: NETWORK_PASSPHRASES.mainnet,
+      network: "PUBLIC",
+      networkUrl: "",
+    });
+    await expect(connectFreighter("mainnet")).resolves.toBe(MOCK_ADDRESS);
+  });
+
+  it("does NOT throw NetworkMismatchError for unknown/custom network (graceful degradation)", async () => {
+    mockGetNetworkDetails.mockResolvedValue({
+      networkPassphrase: "Custom Network ; 2024",
+      network: "STANDALONE",
+      networkUrl: "",
+    });
+    await expect(connectFreighter("testnet")).resolves.toBe(MOCK_ADDRESS);
+  });
+
+  it("does NOT throw NetworkMismatchError when getNetworkDetails fails (graceful degradation)", async () => {
+    mockGetNetworkDetails.mockRejectedValue(new Error("Freighter unavailable"));
+    await expect(connectFreighter("mainnet")).resolves.toBe(MOCK_ADDRESS);
+  });
+});

--- a/app/utils/walletConnect.ts
+++ b/app/utils/walletConnect.ts
@@ -1,5 +1,5 @@
-import { isConnected, getAddress, requestAccess } from "@stellar/freighter-api";
-import { Network } from "../../src/config";
+import { isConnected, getAddress, requestAccess, getNetworkDetails } from "@stellar/freighter-api";
+import { Network, NETWORK_PASSPHRASES } from "../../src/config";
 
 interface AlbedoPublicKeyResult {
   publicKey: string;
@@ -14,6 +14,53 @@ declare global {
     albedo?: Albedo;
   }
 }
+
+/**
+ * Thrown by connectFreighter when the wallet's active network does not match
+ * the network the app is configured to use.
+ */
+export class NetworkMismatchError extends Error {
+  /** The network the app expects (e.g. "testnet") */
+  readonly expected: Network;
+  /** The network Freighter is currently on (e.g. "mainnet") */
+  readonly actual: string;
+
+  constructor(expected: Network, actual: string) {
+    super(
+      `Wallet network mismatch: Freighter is on "${actual}" but the app is set to "${expected}". ` +
+        `Please switch Freighter to "${expected}" and try again.`,
+    );
+    this.name = "NetworkMismatchError";
+    this.expected = expected;
+    this.actual = actual;
+  }
+}
+
+/**
+ * Queries Freighter for the network it is currently connected to and maps it
+ * to one of the app's known Network values ("mainnet" | "testnet").
+ *
+ * Uses the network passphrase as the canonical identifier so the comparison is
+ * robust to display-name variations ("STANDALONE", custom labels, etc.).
+ *
+ * @returns The app-facing network name, or null if Freighter is not installed
+ *          or the network cannot be determined.
+ */
+export const getFreighterNetwork = async (): Promise<Network | null> => {
+  try {
+    const result = await getNetworkDetails();
+    if (result.error || !result.networkPassphrase) {
+      return null;
+    }
+    const passphrase = result.networkPassphrase.trim();
+    if (passphrase === NETWORK_PASSPHRASES.mainnet) return "mainnet";
+    if (passphrase === NETWORK_PASSPHRASES.testnet) return "testnet";
+    // Unknown / custom network — return null so the caller can decide
+    return null;
+  } catch {
+    return null;
+  }
+};
 
 /**
  * Checks if the Freighter browser extension is available.
@@ -36,11 +83,18 @@ export const isFreighterInstalled = async (): Promise<boolean> => {
 };
 
 /**
- * Connects to Freighter wallet and returns the user's public key
- * @param _network - The network to connect to (mainnet or testnet)
+ * Connects to Freighter wallet and returns the user's public key.
+ *
+ * After obtaining access, the wallet's active network is compared against
+ * `network`. If they differ a `NetworkMismatchError` is thrown so the caller
+ * can surface a switch-network prompt instead of silently indexing the wrong
+ * chain.
+ *
+ * @param network - The network the app expects (mainnet or testnet)
+ * @throws {NetworkMismatchError} If Freighter is on a different network
  * @throws {Error} If wallet is not installed, user rejects connection, or any other error occurs
  */
-export const connectFreighter = async (_network: Network): Promise<string> => {
+export const connectFreighter = async (network: Network): Promise<string> => {
   const installed = await isFreighterInstalled();
 
   if (!installed) {
@@ -58,8 +112,18 @@ export const connectFreighter = async (_network: Network): Promise<string> => {
       );
     }
 
+    // Validate that Freighter is on the same network the app expects.
+    // We do this after requestAccess so we only prompt once.
+    const walletNetwork = await getFreighterNetwork();
+    if (walletNetwork !== null && walletNetwork !== network) {
+      throw new NetworkMismatchError(network, walletNetwork);
+    }
+
     return accessResult.address;
   } catch (error: unknown) {
+    if (error instanceof NetworkMismatchError) {
+      throw error;
+    }
     if (error instanceof Error) {
       if (error.message?.includes("User declined")) {
         throw new Error("Connection rejected by user.");
@@ -109,6 +173,16 @@ export const connectAlbedo = async (_network: Network): Promise<string> => {
   }
 
   try {
+    const result = await window.albedo.publicKey({});
+    if (!result?.publicKey) {
+      throw new Error(
+        "Connection rejected. Please approve the connection in Albedo.",
+      );
+    }
+    return result.publicKey;
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      if (error.message?.includes("User declined") || error.message?.includes("rejected")) {
         throw new Error("Connection rejected by user.");
       }
       throw error;


### PR DESCRIPTION
Closes #224

## Summary

The app stored a selected network but never verified that the connected Freighter wallet was actually on that network before routing into indexing. A user with Freighter set to mainnet could silently index the wrong chain when the app was configured for testnet (and vice versa).

This PR adds a network validation step inside `connectFreighter` and surfaces a clear switch-network prompt on the connect page when a mismatch is detected.

---

## Changes

### `app/utils/walletConnect.ts`

**New: `NetworkMismatchError`**
A typed error class with `expected: Network` and `actual: string` fields so the catch site can distinguish a mismatch from any other failure and show targeted UI.

**New: `getFreighterNetwork`**
Calls `getNetworkDetails` from `@stellar/freighter-api` and maps the returned `networkPassphrase` to the app's `Network` type using `NETWORK_PASSPHRASES`. Returns `null` for unknown/custom networks (standalone nodes) so the check degrades gracefully rather than blocking legitimate users.

**Updated: `connectFreighter`**
After `requestAccess` succeeds, calls `getFreighterNetwork` and throws `NetworkMismatchError` when the wallet's network does not match the expected one. A `null` result (unknown network) is treated as a pass-through.

**Fixed: `connectAlbedo`**
Repaired a pre-existing truncated function body (syntax error) that prevented the file from compiling.

### `app/[locale]/connect/page.tsx`

- Added all missing imports (framer-motion, lucide-react, store hooks, wallet utils).
- Added `networkMismatch` state: `{ expected: string; actual: string } | null`.
- `handleFreighterConnect` now catches `NetworkMismatchError` specifically, sets `networkMismatch` state and resets status to `idle` instead of showing a generic red error.
- New yellow mismatch prompt UI (`data-testid="network-mismatch-prompt"`) in the `AnimatePresence` block: shows both network names and a "I've switched — try again" retry button that clears the state and re-runs the connect flow.

### `app/utils/__tests__/walletConnect.network.test.ts`

17 Jest regression tests covering:
- `NetworkMismatchError`: name, fields, Error instance, message content
- `getFreighterNetwork`: mainnet passphrase, testnet passphrase, unknown passphrase, error response, thrown exception, whitespace trimming
- `connectFreighter`: mismatch (mainnet->testnet), mismatch (testnet->mainnet), error fields, match (testnet), match (mainnet), graceful degradation for unknown network, graceful degradation when `getNetworkDetails` throws

---

## How to test

```bash
pnpm test app/utils/__tests__/walletConnect.network.test.ts --no-coverage
# 17 passed
```

Manual flow:
1. Set the app to Testnet.
2. Open Freighter and switch it to Mainnet.
3. Click "Connect with Freighter" on the connect page.
4. The yellow mismatch prompt appears: "Freighter is on mainnet but the app is set to testnet".
5. Switch Freighter to Testnet, click "I've switched — try again" and the connection proceeds normally.

---

## Notes

- Mismatch detection is only implemented for Freighter (the only wallet that exposes a network query API). Albedo, xBull, and WalletConnect do not provide this API and are unchanged.
- Unknown/custom networks (e.g. standalone Soroban nodes) return `null` from `getFreighterNetwork` and are allowed through without a mismatch error.
