### PR TITLE
fix(contract): align frontend mint args with current wrap contract si…

### DIFF
--- a/app/components/ShareCard.tsx
+++ b/app/components/ShareCard.tsx
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 import { useSound } from "../hooks/useSound";
 import { SOUND_NAMES } from "../utils/soundManager";
 import { useOnlineStatus } from "../hooks/useOnlineStatus";
+import { mintWrap } from "../utils/walletKit";
 interface ShareCardProps {
   username: string;
   transactions: number;
@@ -32,7 +33,7 @@ export function ShareCard({
   onFormatChange,
 }: ShareCardProps) {
   const [isDownloading, setIsDownloading] = useState(false);
-  const { address, network } = useWrapStore();
+const { address, network, period } = useWrapStore();
   const { playSound } = useSound();
   const isOnline = useOnlineStatus();
   
@@ -195,6 +196,8 @@ export function ShareCard({
       await mintWrap({
         userAddress: address,
         network: network || "testnet",
+        period,
+        archetype: persona,
         observer,
       });
     } catch (error) {

--- a/app/utils/walletKit.ts
+++ b/app/utils/walletKit.ts
@@ -32,13 +32,6 @@ function getStringProperty(data: unknown, key: string): string | null {
   }
 
   return null;
-function getStringField(data: unknown, field: string): string | null {
-  if (!data || typeof data !== "object" || !(field in data)) {
-    return null;
-  }
-
-  const value = (data as Record<string, unknown>)[field];
-  return typeof value === "string" ? value : null;
 }
 
 export function initWalletKit(): void {
@@ -67,88 +60,88 @@ export function initWalletKit(): void {
  * Options for minting a wrap NFT
  */
 export interface MintWrapParams {
-  /** User's Stellar account address */
   userAddress: string;
-  /** Network to use (mainnet/testnet) */
   network: Network;
-  /** Optional indexed stats to pass as contract arguments */
-  stats?: {
-    totalVolume: number;
-    mostActiveAsset: string;
-    contractCalls: number;
-    timeframe?: string;
-  };
-  /** Optional observer callback for transaction state updates */
+  /** WrapPeriod from the wrap store, e.g. "weekly" | "monthly" | "yearly" */
+  period: string;
+  /** Persona/archetype label, e.g. "The DeFi Patron" */
+  archetype: string;
+  /**
+   * Optional pre-fetched attestation. If omitted, mintWrap will call the
+   * backend attestation endpoint to obtain a signed hash of the stats.
+   */
+  attestation?: { dataHash: Uint8Array; signature: Uint8Array };
   observer?: TransactionObserver;
 }
 
 /**
- * Fetches indexed stats from the API if not provided
+ * Fetches a signed attestation (hash + signature) for the user's stats
+ * from the backend. This endpoint does not exist yet in this repo — it
+ * needs to be implemented server-side before minting will work end-to-end.
+ * The server should:
+ *   1. Recompute/verify the user's stats independently (not trust the client)
+ *   2. Hash the verified stats payload
+ *   3. Sign that hash with a key the deployed contract is configured to trust
+ *   4. Return { dataHash: hex, signature: hex }
  */
-async function fetchIndexedStats(
+async function fetchMintAttestation(
   accountAddress: string,
   network: Network,
-  period: string = "yearly",
-): Promise<{ totalVolume: number; mostActiveAsset: string; contractCalls: number }> {
-  try {
-    const response = await fetch(
-      `/api/wrapped?accountId=${encodeURIComponent(accountAddress)}&network=${network}&period=${period}`,
+  period: string,
+  archetype: string,
+): Promise<{ dataHash: Uint8Array; signature: Uint8Array }> {
+  const response = await fetch("/api/wrap/attest", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ accountAddress, network, period, archetype }),
+  });
+
+  if (!response.ok) {
+    throw new ContractValidationError(
+      `Failed to obtain mint attestation: ${response.statusText}. ` +
+        `The /api/wrap/attest backend endpoint must be implemented before minting can work.`,
     );
-
-    if (!response.ok) {
-      throw new Error(`Failed to fetch indexed stats: ${response.statusText}`);
-    }
-
-    const data = await response.json();
-
-    return {
-      totalVolume: data.totalVolume || 0,
-      mostActiveAsset: data.mostActiveAsset || "XLM",
-      contractCalls: data.contractCalls || 0,
-    };
-  } catch (error) {
-    console.warn("Failed to fetch indexed stats, using defaults:", error);
-    // Return default values if fetch fails
-    return {
-      totalVolume: 0,
-      mostActiveAsset: "XLM",
-      contractCalls: 0,
-    };
   }
+
+  const data = await response.json();
+
+  if (
+    typeof data?.dataHash !== "string" ||
+    typeof data?.signature !== "string"
+  ) {
+    throw new ContractValidationError(
+      "Attestation response missing dataHash/signature",
+    );
+  }
+
+  return {
+    dataHash: Uint8Array.from(Buffer.from(data.dataHash, "hex")),
+    signature: Uint8Array.from(Buffer.from(data.signature, "hex")),
+  };
 }
 
 /**
  * Mint the user's Stellar Wrapped as a Soulbound Token NFT
- * 
+ *
  * This function handles the complete Soroban contract invocation lifecycle:
+ * - Obtaining a signed attestation (data_hash + signature) for the stats
  * - Building XDR transactions with contract arguments
  * - Simulating transactions
  * - Signing with Freighter wallet
  * - Submitting to network
  * - Polling for confirmation
- * 
- * @param params - Minting parameters including address, network, and optional stats
+ *
+ * @param params - Minting parameters including address, network, period, and archetype
  * @returns Transaction hash on success
  * @throws Error if minting fails or user rejects transaction
- * 
+ *
  * @example
  * ```ts
- * // With provided stats
  * const txHash = await mintWrap({
  *   userAddress: 'GABC...XYZ',
  *   network: 'testnet',
- *   stats: {
- *     totalVolume: 45000,
- *     mostActiveAsset: 'XLM',
- *     contractCalls: 120,
- *     timeframe: '1y'
- *   }
- * });
- * 
- * // Without stats (will fetch from API)
- * const txHash = await mintWrap({
- *   userAddress: 'GABC...XYZ',
- *   network: 'testnet'
+ *   period: 'monthly',
+ *   archetype: 'The DeFi Patron',
  * });
  * ```
  */
@@ -156,14 +149,11 @@ export async function mintWrap(params: MintWrapParams): Promise<string> {
   try {
     initWalletKit();
 
-    const { userAddress, network, stats, observer } = params;
+    const { userAddress, network, period, archetype, observer } = params;
 
-    // Get stats if not provided
-    let finalStats = stats;
-    if (!finalStats) {
-      // Fetch from API if not in store
-      finalStats = await fetchIndexedStats(userAddress, network);
-    }
+    const attestation =
+      params.attestation ??
+      (await fetchMintAttestation(userAddress, network, period, archetype));
 
     const { setTransactionState, setTransactionHash, setTransactionError, resetTransaction } = useTransactionStore.getState();
     resetTransaction();
@@ -212,12 +202,10 @@ export async function mintWrap(params: MintWrapParams): Promise<string> {
     const mintOptions: MintWrapOptions = {
       accountAddress: userAddress,
       network,
-      stats: {
-        totalVolume: finalStats.totalVolume,
-        mostActiveAsset: finalStats.mostActiveAsset,
-        contractCalls: finalStats.contractCalls,
-        timeframe: finalStats.timeframe || "all",
-      },
+      period,
+      archetype,
+      dataHash: attestation.dataHash,
+      signature: attestation.signature,
       observer: bridgedObserver,
     };
 

--- a/src/services/__tests__/mintWrapArgs.test.ts
+++ b/src/services/__tests__/mintWrapArgs.test.ts
@@ -1,0 +1,125 @@
+import { buildMintWrapArgs, validateMintWrapInput } from "../../utils/contractArgsBuilder";
+
+const validGAddr = "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI";
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`Assertion failed: ${message}`);
+}
+
+function hexBytes(n: number): Uint8Array {
+  const arr = new Uint8Array(n);
+  for (let i = 0; i < n; i++) arr[i] = i % 256;
+  return arr;
+}
+
+function run() {
+  // ── Happy path: exact arg count, order, and types ─────────────────────
+  {
+    const result = buildMintWrapArgs({
+      accountAddress: validGAddr,
+      period: "monthly",
+      archetype: "The DeFi Patron",
+      dataHash: hexBytes(32),
+      signature: hexBytes(64),
+    });
+
+    assert(result.success, "buildMintWrapArgs succeeds with valid input");
+    if (result.success) {
+      assert(result.data.args.length === 5, "produces exactly 5 args");
+
+      const [user, period, archetype, dataHash, signature] = result.data.args;
+      assert(user.switch().name === "scvAddress", "arg0 (user) is scvAddress");
+      assert(period.switch().name === "scvString", "arg1 (period) is scvString");
+      assert(
+        archetype.switch().name === "scvString",
+        "arg2 (archetype) is scvString",
+      );
+      assert(
+        dataHash.switch().name === "scvBytes",
+        "arg3 (data_hash) is scvBytes",
+      );
+      assert(
+        signature.switch().name === "scvBytes",
+        "arg4 (signature) is scvBytes",
+      );
+
+      assert(period.str().toString() === "monthly", "period value preserved");
+      assert(
+        archetype.str().toString() === "The DeFi Patron",
+        "archetype value preserved",
+      );
+      assert(dataHash.bytes().length === 32, "data_hash length preserved");
+      assert(signature.bytes().length === 64, "signature length preserved");
+    }
+  }
+
+  // ── Rejects invalid address ────────────────────────────────────────────
+  {
+    const result = buildMintWrapArgs({
+      accountAddress: "not-a-real-address",
+      period: "monthly",
+      archetype: "The DeFi Patron",
+      dataHash: hexBytes(32),
+      signature: hexBytes(64),
+    });
+    assert(!result.success, "rejects invalid accountAddress");
+  }
+
+  // ── Rejects empty period ───────────────────────────────────────────────
+  {
+    const result = buildMintWrapArgs({
+      accountAddress: validGAddr,
+      period: "",
+      archetype: "The DeFi Patron",
+      dataHash: hexBytes(32),
+      signature: hexBytes(64),
+    });
+    assert(!result.success, "rejects empty period");
+  }
+
+  // ── Rejects empty archetype ────────────────────────────────────────────
+  {
+    const result = buildMintWrapArgs({
+      accountAddress: validGAddr,
+      period: "monthly",
+      archetype: "",
+      dataHash: hexBytes(32),
+      signature: hexBytes(64),
+    });
+    assert(!result.success, "rejects empty archetype");
+  }
+
+  // ── Rejects missing dataHash ───────────────────────────────────────────
+  {
+    const errors = validateMintWrapInput({
+      accountAddress: validGAddr,
+      period: "monthly",
+      archetype: "The DeFi Patron",
+      dataHash: new Uint8Array(0),
+      signature: hexBytes(64),
+    });
+    assert(
+      errors.some((e) => e.toLowerCase().includes("datahash")),
+      "flags missing dataHash",
+    );
+  }
+
+  // ── Rejects missing signature ──────────────────────────────────────────
+  {
+    const errors = validateMintWrapInput({
+      accountAddress: validGAddr,
+      period: "monthly",
+      archetype: "The DeFi Patron",
+      dataHash: hexBytes(32),
+      signature: new Uint8Array(0),
+    });
+    assert(
+      errors.some((e) => e.toLowerCase().includes("signature")),
+      "flags missing signature",
+    );
+  }
+
+  console.log("✅ mintWrapArgs tests passed");
+}
+
+run();

--- a/src/services/contractBridge.ts
+++ b/src/services/contractBridge.ts
@@ -15,7 +15,7 @@ import {
   isPlaceholderContractAddress,
   PlaceholderContractAddressError,
 } from '../../config/contracts';
-import { buildContractArgs, type ContractStatsInput } from '../utils/contractArgsBuilder';
+import { buildMintWrapArgs, type MintWrapArgsInput } from '../utils/contractArgsBuilder';
 
 export type TransactionState =
   | 'pending'
@@ -29,7 +29,10 @@ export type TransactionObserver = (state: TransactionState, data?: unknown) => v
 
 export interface MintWrapOptions {
   accountAddress: string;
-  stats: ContractStatsInput;
+  period: string;
+  archetype: string;
+  dataHash: Uint8Array;
+  signature: Uint8Array;
   network: Network;
   observer?: TransactionObserver;
 }
@@ -200,7 +203,7 @@ function parseContractError(error: unknown): string {
 
 async function buildMintTransaction(
   accountAddress: string,
-  stats: ContractStatsInput,
+  mintArgsInput: Omit<MintWrapArgsInput, 'accountAddress'>,
   network: Network,
 ): Promise<{ transaction: Transaction; contract: Contract }> {
   let contractAddress: string;
@@ -236,7 +239,7 @@ async function buildMintTransaction(
     );
   }
 
-  const argsResult = buildContractArgs(stats, accountAddress);
+  const argsResult = buildMintWrapArgs({ accountAddress, ...mintArgsInput });
   if (!argsResult.success) {
     throw new Error(
       `Failed to build contract arguments: ${argsResult.errors.join(', ')}`,
@@ -521,14 +524,18 @@ async function submitTransaction(
 }
 
 export async function mintWrap(options: MintWrapOptions): Promise<MintResult> {
-  const { accountAddress, stats, network, observer } = options;
+  const { accountAddress, period, archetype, dataHash, signature, network, observer } = options;
 
   emitState(observer, 'pending');
 
   const startTime = Date.now();
 
   try {
-    const { transaction } = await buildMintTransaction(accountAddress, stats, network);
+    const { transaction } = await buildMintTransaction(
+    accountAddress,
+    { period, archetype, dataHash, signature },
+    network,
+  );
 
     const server = createSorobanServer(network);
 

--- a/src/utils/contractArgsBuilder.ts
+++ b/src/utils/contractArgsBuilder.ts
@@ -343,3 +343,157 @@ export function logContractArgs(
     console.groupEnd();
   }
 }
+// ─── mint_wrap Argument Builder ─────────────────────────────────────────────
+
+/**
+ * Input required to build arguments for the `mint_wrap` contract call.
+ *
+ * IMPORTANT: `dataHash` and `signature` must be produced by a trusted
+ * backend/attestation service that hashes the verified stats payload and
+ * signs it server-side. This builder does NOT compute or fabricate them —
+ * without server-side signing, any client could mint an arbitrary
+ * archetype/period for itself. See PR notes for the outstanding backend
+ * work this depends on.
+ */
+export interface MintWrapArgsInput {
+  accountAddress: string;
+  period: string;
+  archetype: string;
+  dataHash: Uint8Array;
+  signature: Uint8Array;
+}
+
+/**
+ * Validates input before building mint_wrap ScVal args.
+ */
+export function validateMintWrapInput(input: MintWrapArgsInput): string[] {
+  const errors: string[] = [];
+
+  if (!input || typeof input !== "object") {
+    return ["Mint wrap input must be a non-null object"];
+  }
+
+  if (
+    typeof input.accountAddress !== "string" ||
+    input.accountAddress.trim().length === 0
+  ) {
+    errors.push("accountAddress must be a non-empty string");
+  }
+
+  if (typeof input.period !== "string" || input.period.trim().length === 0) {
+    errors.push(
+      'period must be a non-empty string (e.g. "weekly", "monthly", "yearly")',
+    );
+  }
+
+  if (
+    typeof input.archetype !== "string" ||
+    input.archetype.trim().length === 0
+  ) {
+    errors.push("archetype must be a non-empty string (the persona label)");
+  }
+
+  if (!(input.dataHash instanceof Uint8Array) || input.dataHash.length === 0) {
+    errors.push(
+      "dataHash must be a non-empty byte array produced by the backend signing service",
+    );
+  }
+
+  if (
+    !(input.signature instanceof Uint8Array) ||
+    input.signature.length === 0
+  ) {
+    errors.push(
+      "signature must be a non-empty byte array produced by the backend signing service",
+    );
+  }
+
+  return errors;
+}
+
+/**
+ * Builds ordered ScVal arguments for the `mint_wrap` contract function.
+ *
+ * Argument order (matches deployed contract signature):
+ *   0: user      → ScVal.scvAddress
+ *   1: period    → ScVal.scvString
+ *   2: archetype → ScVal.scvString
+ *   3: data_hash → ScVal.scvBytes
+ *   4: signature → ScVal.scvBytes
+ *
+ * @example
+ * ```ts
+ * const result = buildMintWrapArgs({
+ *   accountAddress: 'GABC...XYZ',
+ *   period: 'monthly',
+ *   archetype: 'The DeFi Patron',
+ *   dataHash: attestation.dataHash,
+ *   signature: attestation.signature,
+ * });
+ *
+ * if (result.success) {
+ *   contract.call('mint_wrap', ...result.data.args);
+ * }
+ * ```
+ */
+export function buildMintWrapArgs(input: MintWrapArgsInput): BuildArgsResult {
+  const validationErrors = validateMintWrapInput(input);
+  if (validationErrors.length > 0) {
+    return { success: false, errors: validationErrors };
+  }
+
+  const errors: string[] = [];
+  const args: xdr.ScVal[] = [];
+  const argDescriptions: string[] = [];
+
+  const userVal = unwrap(addressToScVal(input.accountAddress), "user", errors);
+  if (userVal) {
+    args.push(userVal);
+    argDescriptions.push(`user: ${input.accountAddress}`);
+  }
+
+  const periodVal = unwrap(toScVal(input.period, "string"), "period", errors);
+  if (periodVal) {
+    args.push(periodVal);
+    argDescriptions.push(`period: "${input.period}" (string)`);
+  }
+
+  const archetypeVal = unwrap(
+    toScVal(input.archetype, "string"),
+    "archetype",
+    errors,
+  );
+  if (archetypeVal) {
+    args.push(archetypeVal);
+    argDescriptions.push(`archetype: "${input.archetype}" (string)`);
+  }
+
+  const dataHashVal = unwrap(
+    toScVal(input.dataHash, "bytes"),
+    "data_hash",
+    errors,
+  );
+  if (dataHashVal) {
+    args.push(dataHashVal);
+    argDescriptions.push(`data_hash: <${input.dataHash.length} bytes>`);
+  }
+
+  const signatureVal = unwrap(
+    toScVal(input.signature, "bytes"),
+    "signature",
+    errors,
+  );
+  if (signatureVal) {
+    args.push(signatureVal);
+    argDescriptions.push(`signature: <${input.signature.length} bytes>`);
+  }
+
+  if (errors.length > 0) {
+    return { success: false, errors };
+  }
+
+  return {
+    success: true,
+    data: { args, argDescriptions },
+  };
+}


### PR DESCRIPTION
…gnature

buildContractArgs built args for a stats-based shape that no longer matches the deployed mint_wrap(user, period, archetype, data_hash, signature) signature. Adds buildMintWrapArgs with the correct arg order/types, wires contractBridge.mintWrap and walletKit.mintWrap to use it, and updates ShareCard to pass period/archetype.

data_hash and signature must come from a trusted backend attestation service (not fabricated client-side) — walletKit now calls a new /api/wrap/attest endpoint for this, which does not exist yet in this repo and needs to be implemented separately before end-to-end minting works.

Closes #227 