### PR TITLE
test(share): extract and test social platform URL generation

### DIFF
--- a/__tests__/shareUrl.test.ts
+++ b/__tests__/shareUrl.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { generatePlatformShareUrl, generateShareText } from "../app/utils/shareUrl";
+
+describe("shareUrl helpers", () => {
+  describe("generateShareText", () => {
+    it("generates correct share text including persona and vibes", () => {
+      const text = generateShareText(150, "DeFi Degen", 85, "Bullish");
+      expect(text).toBe(
+        "Check out my Stellar Wrapped 2026! 150 transactions, DeFi Degen persona, 85% Bullish! 🎉 #StellarWrapped"
+      );
+    });
+  });
+
+  describe("generatePlatformShareUrl", () => {
+    const testUrl = "https://example.com/share?preview=true";
+    const testText = "Check out my wrapped & vibes!";
+
+    it("generates correct X (Twitter) URL with encoded text and URL", () => {
+      const url = generatePlatformShareUrl("x", testUrl, testText);
+      expect(url).toBe(
+        `https://twitter.com/intent/tweet?text=${encodeURIComponent(testText)}&url=${encodeURIComponent(testUrl)}`
+      );
+    });
+
+    it("generates correct WhatsApp URL with encoded text and URL", () => {
+      const url = generatePlatformShareUrl("whatsapp", testUrl, testText);
+      expect(url).toBe(
+        `https://wa.me/?text=${encodeURIComponent(testText + " " + testUrl)}`
+      );
+    });
+
+    it("generates correct Facebook URL with encoded URL", () => {
+      const url = generatePlatformShareUrl("facebook", testUrl, testText);
+      expect(url).toBe(
+        `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(testUrl)}`
+      );
+    });
+
+    it("generates correct LinkedIn URL with encoded URL", () => {
+      const url = generatePlatformShareUrl("linkedin", testUrl, testText);
+      expect(url).toBe(
+        `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(testUrl)}`
+      );
+    });
+
+    it("generates correct Telegram URL with encoded text and URL", () => {
+      const url = generatePlatformShareUrl("telegram", testUrl, testText);
+      expect(url).toBe(
+        `https://t.me/share/url?url=${encodeURIComponent(testUrl)}&text=${encodeURIComponent(testText)}`
+      );
+    });
+
+    it("returns empty string for unknown platform", () => {
+      const url = generatePlatformShareUrl("unknown", testUrl, testText);
+      expect(url).toBe("");
+    });
+  });
+});

--- a/app/[locale]/share/SharePageClient.tsx
+++ b/app/[locale]/share/SharePageClient.tsx
@@ -27,6 +27,7 @@ import {
   parseSharePreviewParams,
   type SharePreviewState,
 } from "@/app/utils/sharePreviewParams";
+import { generatePlatformShareUrl, generateShareText } from "@/app/utils/shareUrl";
 
 const SocialIcons = {
   X: XIcon,
@@ -102,29 +103,11 @@ export default function SharePageClient() {
   const handleShare = (platform: string) => {
     trackEvent("share_clicked", { platform });
     const url = shareUrl || window.location.href;
-    const text = `Check out my Stellar Wrapped 2026! ${transactions} transactions, ${persona} persona, ${vibePercentage}% ${topVibe}! 🎉 #StellarWrapped`;
-    let shareUrl = "";
+    const text = generateShareText(transactions, persona, vibePercentage, topVibe);
+    const finalShareUrl = generatePlatformShareUrl(platform, url, text);
 
-    switch (platform) {
-      case "x":
-        shareUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}`;
-        break;
-      case "whatsapp":
-        shareUrl = `https://wa.me/?text=${encodeURIComponent(text + " " + url)}`;
-        break;
-      case "facebook":
-        shareUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}`;
-        break;
-      case "linkedin":
-        shareUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(url)}`;
-        break;
-      case "telegram":
-        shareUrl = `https://t.me/share/url?url=${encodeURIComponent(url)}&text=${encodeURIComponent(text)}`;
-        break;
-    }
-
-    if (shareUrl) {
-      window.open(shareUrl, "_blank", "width=600,height=500");
+    if (finalShareUrl) {
+      window.open(finalShareUrl, "_blank", "width=600,height=500");
     }
     setShareOpen(false);
   };

--- a/app/utils/shareUrl.ts
+++ b/app/utils/shareUrl.ts
@@ -1,0 +1,25 @@
+export function generateShareText(
+  transactions: number | string,
+  persona: string,
+  vibePercentage: number | string,
+  topVibe: string
+): string {
+  return `Check out my Stellar Wrapped 2026! ${transactions} transactions, ${persona} persona, ${vibePercentage}% ${topVibe}! 🎉 #StellarWrapped`;
+}
+
+export function generatePlatformShareUrl(platform: string, url: string, text: string): string {
+  switch (platform.toLowerCase()) {
+    case "x":
+      return `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}`;
+    case "whatsapp":
+      return `https://wa.me/?text=${encodeURIComponent(text + " " + url)}`;
+    case "facebook":
+      return `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}`;
+    case "linkedin":
+      return `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(url)}`;
+    case "telegram":
+      return `https://t.me/share/url?url=${encodeURIComponent(url)}&text=${encodeURIComponent(text)}`;
+    default:
+      return "";
+  }
+}


### PR DESCRIPTION
 This PR resolves #282 by extracting the social share URL generation logic into a fully tested, pure helper module.

Changes Included:

Refactoring: Moved the handleShare switch statement out of SharePageClient.tsx into two pure functions: generateShareText and generatePlatformShareUrl located in app/utils/shareUrl.ts.
Testing: Added __tests__/shareUrl.test.ts to comprehensively test the URL structures for all platforms (X, WhatsApp, Facebook, LinkedIn, Telegram).
Encoding Verification: The tests explicitly verify that dynamic user text (such as "persona" and "vibes") and the target preview URL are properly handled by encodeURIComponent().
Acceptance Criteria Verified:

 Extracted share URL generation into a pure helper.
 Tested X, WhatsApp, Facebook, LinkedIn, and Telegram URLs.
 Covered URL encoding for persona and vibe text.
 closes #282 