### PR TITLE
fix(api): normalize and validate period query parameter

### DIFF
--- a/app/api/wrapped/__tests__/route.test.ts
+++ b/app/api/wrapped/__tests__/route.test.ts
@@ -55,13 +55,60 @@ describe("GET /api/wrapped route validation", () => {
     expect(data.error).toContain("Stellar address must start with G");
   });
 
-  it("processes request successfully for valid public key", async () => {
-    // Valid Stellar public key
-    const validAccountId = "GB3K3MUDMFEVFTY3ZZW7MOM62G3BYVZZN4MHTI6M2U7J3H4T4Z4Q3G6I";
-    const req = createRequest(`/api/wrapped?accountId=${validAccountId}`);
-    const response = await GET(req);
-    expect(response.status).toBe(200);
-    const data = await response.json();
-    expect(data.success).toBe(true);
+  describe("period query parameter normalization", () => {
+    // Use a properly formatted valid Stellar test address
+    const validAccountId = "GDRZZGQDRBLJBAY24O3EMZFDGZ4EY6A7L24OERKQTPLT4T7SZKLUAZVQ";
+
+    it("defaults to monthly when period is missing", async () => {
+      const req = createRequest(`/api/wrapped?accountId=${validAccountId}`);
+      const response = await GET(req);
+      expect(response.status).toBe(200);
+    });
+
+    it("accepts lowercase period values", async () => {
+      const req = createRequest(
+        `/api/wrapped?accountId=${validAccountId}&period=weekly`,
+      );
+      const response = await GET(req);
+      expect(response.status).toBe(200);
+    });
+
+    it("normalizes uppercase period to lowercase", async () => {
+      const req = createRequest(
+        `/api/wrapped?accountId=${validAccountId}&period=YEARLY`,
+      );
+      const response = await GET(req);
+      expect(response.status).toBe(200);
+    });
+
+    it("normalizes mixed-case period to lowercase", async () => {
+      const req = createRequest(
+        `/api/wrapped?accountId=${validAccountId}&period=Monthly`,
+      );
+      const response = await GET(req);
+      expect(response.status).toBe(200);
+    });
+
+    it("returns 400 for invalid period values", async () => {
+      const req = createRequest(
+        `/api/wrapped?accountId=${validAccountId}&period=daily`,
+      );
+      const response = await GET(req);
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error).toBe("Invalid period");
+      expect(data.details).toContain("weekly");
+      expect(data.details).toContain("monthly");
+      expect(data.details).toContain("yearly");
+    });
+
+    it("uses only the first value when period is repeated", async () => {
+      // URLSearchParams.get() returns the first value
+      const req = createRequest(
+        `/api/wrapped?accountId=${validAccountId}&period=yearly&period=weekly`,
+      );
+      const response = await GET(req);
+      expect(response.status).toBe(200);
+    });
   });
 });

--- a/app/api/wrapped/route.ts
+++ b/app/api/wrapped/route.ts
@@ -5,7 +5,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { indexAccount } from "@/app/services/indexerServer";
-import { WrapPeriod, PERIODS } from "@/app/utils/indexer";
+import { PERIODS, normalizePeriod } from "@/app/utils/indexer";
 import { validateStellarAddress } from "@/src/utils/validateStellarAddress";
 
 export async function GET(request: NextRequest) {
@@ -14,7 +14,10 @@ export async function GET(request: NextRequest) {
     const accountId = searchParams.get("accountId");
     const network =
       (searchParams.get("network") as "mainnet" | "testnet") || "mainnet";
-    const period = (searchParams.get("period") as WrapPeriod) || "monthly";
+    const rawPeriod = searchParams.get("period");
+    const period = rawPeriod === null
+      ? "monthly"
+      : normalizePeriod(rawPeriod);
 
     // Validate inputs
     if (!accountId) {
@@ -36,8 +39,14 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "Invalid network" }, { status: 400 });
     }
 
-    if (!PERIODS[period]) {
-      return NextResponse.json({ error: "Invalid period" }, { status: 400 });
+    if (!period) {
+      return NextResponse.json(
+        {
+          error: "Invalid period",
+          details: `Accepted values: ${Object.keys(PERIODS).join(", ")}`,
+        },
+        { status: 400 },
+      );
     }
 
     // Server-safe indexer (no IndexedDB) — returns live Horizon data

--- a/app/utils/__tests__/indexer.test.ts
+++ b/app/utils/__tests__/indexer.test.ts
@@ -1,6 +1,41 @@
-import { getCacheKey, isCacheValid, CACHE_VERSION, CACHE_TTL_MINUTES } from '../indexer';
+import { getCacheKey, isCacheValid, CACHE_VERSION, CACHE_TTL_MINUTES, normalizePeriod } from '../indexer';
 
 describe('indexer utils', () => {
+  describe('normalizePeriod', () => {
+    it('returns a valid WrapPeriod for lowercase input', () => {
+      expect(normalizePeriod('weekly')).toBe('weekly');
+      expect(normalizePeriod('monthly')).toBe('monthly');
+      expect(normalizePeriod('yearly')).toBe('yearly');
+      expect(normalizePeriod('biweekly')).toBe('biweekly');
+    });
+
+    it('normalizes uppercase input to lowercase', () => {
+      expect(normalizePeriod('WEEKLY')).toBe('weekly');
+      expect(normalizePeriod('Monthly')).toBe('monthly');
+      expect(normalizePeriod('YEARLY')).toBe('yearly');
+    });
+
+    it('normalizes mixed-case input', () => {
+      expect(normalizePeriod('WeEkLy')).toBe('weekly');
+    });
+
+    it('trims whitespace', () => {
+      expect(normalizePeriod('  monthly  ')).toBe('monthly');
+    });
+
+    it('returns null for invalid period strings', () => {
+      expect(normalizePeriod('daily')).toBeNull();
+      expect(normalizePeriod('quarterly')).toBeNull();
+      expect(normalizePeriod('')).toBeNull();
+      expect(normalizePeriod('   ')).toBeNull();
+    });
+
+    it('returns null for null or undefined', () => {
+      expect(normalizePeriod(null)).toBeNull();
+      expect(normalizePeriod(undefined)).toBeNull();
+    });
+  });
+
   describe('getCacheKey', () => {
     it('includes accountId, network, period, and cache version', () => {
       const key = getCacheKey('GABC', 'mainnet', 'monthly');

--- a/app/utils/indexer.ts
+++ b/app/utils/indexer.ts
@@ -102,6 +102,18 @@ export const NEXT_PUBLIC_RPC_ENDPOINTS = {
   testnet: "https://horizon-testnet.stellar.org",
 };
 
+/**
+ * Normalizes a raw period query-string value into a valid WrapPeriod.
+ * Handles casing differences and trims whitespace.
+ * Returns `null` when the input cannot be mapped to a known period.
+ */
+export function normalizePeriod(raw: string | null | undefined): WrapPeriod | null {
+  if (raw == null) return null;
+  const trimmed = raw.trim().toLowerCase();
+  if (trimmed in PERIODS) return trimmed as WrapPeriod;
+  return null;
+}
+
 export function getCacheKey(
   accountId: string,
   network: "mainnet" | "testnet",


### PR DESCRIPTION
## Summary
- Adds `normalizePeriod()` utility to handle case-insensitive period parsing and whitespace trimming
- API route now distinguishes missing period (defaults to `monthly`) from invalid period (returns `400` with accepted values)
- Removes unsafe `as WrapPeriod` cast in favor of proper validation

Closes #245

## Test plan
- [x] Unit tests for `normalizePeriod()` — lowercase, uppercase, mixed-case, whitespace, null, undefined, invalid strings
- [x] Integration tests for API route — missing period defaults, uppercase/mixed-case normalization, invalid period 400 response, repeated params

🤖 Generated with [Claude Code](https://claude.com/claude-code)