### PR TITLE
fix(api): add cache-control headers to wrapped responses

### DIFF
--- a/app/api/wrapped/__tests__/route.test.ts
+++ b/app/api/wrapped/__tests__/route.test.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 import { GET } from "../route";
+import { CACHE_TTL_MINUTES } from "@/app/utils/indexer";
 
 // Mock the indexer to isolate route logic
 jest.mock("@/app/services/indexerServer", () => ({
@@ -10,6 +11,8 @@ jest.mock("@/app/services/indexerServer", () => ({
     refreshingInBackground: false,
   }),
 }));
+
+const VALID_ACCOUNT_ID = "GDRZZGQDRBLJBAY24O3EMZFDGZ4EY6A7L24OERKQTPLT4T7SZKLUAZVQ";
 
 describe("GET /api/wrapped route validation", () => {
   const createRequest = (url: string) => {
@@ -56,12 +59,43 @@ describe("GET /api/wrapped route validation", () => {
   });
 
   it("processes request successfully for valid public key", async () => {
-    // Valid Stellar public key
-    const validAccountId = "GB3K3MUDMFEVFTY3ZZW7MOM62G3BYVZZN4MHTI6M2U7J3H4T4Z4Q3G6I";
-    const req = createRequest(`/api/wrapped?accountId=${validAccountId}`);
+    const req = createRequest(`/api/wrapped?accountId=${VALID_ACCOUNT_ID}`);
     const response = await GET(req);
     expect(response.status).toBe(200);
     const data = await response.json();
     expect(data.success).toBe(true);
+  });
+
+  describe("cache-control headers", () => {
+    it("sets private Cache-Control on successful responses", async () => {
+      const req = createRequest(`/api/wrapped?accountId=${VALID_ACCOUNT_ID}`);
+      const response = await GET(req);
+      expect(response.status).toBe(200);
+      const cc = response.headers.get("Cache-Control");
+      expect(cc).toContain("private");
+      expect(cc).toContain(`max-age=${CACHE_TTL_MINUTES * 60}`);
+    });
+
+    it("sets no-store Cache-Control on 400 error responses", async () => {
+      const req = createRequest("/api/wrapped");
+      const response = await GET(req);
+      expect(response.status).toBe(400);
+      expect(response.headers.get("Cache-Control")).toBe("no-store");
+    });
+
+    it("sets no-store Cache-Control on validation error responses", async () => {
+      const req = createRequest("/api/wrapped?accountId=GSHORTID");
+      const response = await GET(req);
+      expect(response.status).toBe(400);
+      expect(response.headers.get("Cache-Control")).toBe("no-store");
+    });
+
+    it("includes stale-while-revalidate for successful responses", async () => {
+      const req = createRequest(`/api/wrapped?accountId=${VALID_ACCOUNT_ID}`);
+      const response = await GET(req);
+      expect(response.status).toBe(200);
+      const cc = response.headers.get("Cache-Control");
+      expect(cc).toContain("stale-while-revalidate=60");
+    });
   });
 });

--- a/app/api/wrapped/route.ts
+++ b/app/api/wrapped/route.ts
@@ -5,8 +5,25 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { indexAccount } from "@/app/services/indexerServer";
-import { WrapPeriod, PERIODS } from "@/app/utils/indexer";
+import { WrapPeriod, PERIODS, CACHE_TTL_MINUTES } from "@/app/utils/indexer";
 import { validateStellarAddress } from "@/src/utils/validateStellarAddress";
+
+/** Cache-Control header for successful, user-specific responses. */
+const SUCCESS_CACHE_CONTROL = `private, max-age=${CACHE_TTL_MINUTES * 60}, stale-while-revalidate=60`;
+
+/** Cache-Control header for error responses – never cache failures. */
+const ERROR_CACHE_CONTROL = "no-store";
+
+function jsonWithCache(
+  body: Record<string, unknown>,
+  init: { status: number; cache?: string },
+) {
+  const cacheControl = init.cache ?? (init.status >= 400 ? ERROR_CACHE_CONTROL : SUCCESS_CACHE_CONTROL);
+  return NextResponse.json(body, {
+    status: init.status,
+    headers: { "Cache-Control": cacheControl },
+  });
+}
 
 export async function GET(request: NextRequest) {
   try {
@@ -18,7 +35,7 @@ export async function GET(request: NextRequest) {
 
     // Validate inputs
     if (!accountId) {
-      return NextResponse.json(
+      return jsonWithCache(
         { error: "Missing accountId parameter" },
         { status: 400 },
       );
@@ -26,29 +43,32 @@ export async function GET(request: NextRequest) {
 
     const validationResult = validateStellarAddress(accountId, network as any);
     if (!validationResult.isValid) {
-      return NextResponse.json(
+      return jsonWithCache(
         { error: validationResult.error || "Invalid account ID format" },
         { status: 400 },
       );
     }
 
     if (!["mainnet", "testnet"].includes(network)) {
-      return NextResponse.json({ error: "Invalid network" }, { status: 400 });
+      return jsonWithCache({ error: "Invalid network" }, { status: 400 });
     }
 
     if (!PERIODS[period]) {
-      return NextResponse.json({ error: "Invalid period" }, { status: 400 });
+      return jsonWithCache({ error: "Invalid period" }, { status: 400 });
     }
 
     // Server-safe indexer (no IndexedDB) — returns live Horizon data
     const response = await indexAccount(accountId, network, period);
 
-    return NextResponse.json({
-      ...response.result,
-      cached: response.fromCache,
-      cacheTimestamp: response.cacheTimestamp,
-      refreshingInBackground: response.refreshingInBackground,
-    });
+    return jsonWithCache(
+      {
+        ...response.result,
+        cached: response.fromCache,
+        cacheTimestamp: response.cacheTimestamp,
+        refreshingInBackground: response.refreshingInBackground,
+      },
+      { status: 200 },
+    );
   } catch (error: unknown) {
     console.error("Error in /api/wrapped:", error);
 
@@ -63,7 +83,7 @@ export async function GET(request: NextRequest) {
       message.includes("not found") ||
       statusCode === 404
     ) {
-      return NextResponse.json(
+      return jsonWithCache(
         {
           error: "Account not found on this network",
           details:
@@ -75,7 +95,7 @@ export async function GET(request: NextRequest) {
 
     // Check for rate limiting
     if (statusCode === 429) {
-      return NextResponse.json(
+      return jsonWithCache(
         { error: "Rate limited. Please try again later." },
         { status: 429 },
       );
@@ -83,7 +103,7 @@ export async function GET(request: NextRequest) {
 
     // Check for Horizon server errors
     if (statusCode === 500) {
-      return NextResponse.json(
+      return jsonWithCache(
         { error: "Horizon server error" },
         { status: 500 },
       );
@@ -91,13 +111,13 @@ export async function GET(request: NextRequest) {
 
     // Check for Bad Request (pagination or other API issues)
     if (message.includes("Bad Request") || statusCode === 400) {
-      return NextResponse.json(
+      return jsonWithCache(
         { error: "Bad Request to Horizon API" },
         { status: 400 },
       );
     }
 
-    return NextResponse.json(
+    return jsonWithCache(
       {
         error: "Failed to fetch wrapped data",
         details: error instanceof Error ? error.message : String(error),


### PR DESCRIPTION
## Summary
- Adds `Cache-Control: private, max-age=3600, stale-while-revalidate=60` to successful wrapped API responses (user-specific data should not be stored in shared caches)
- Adds `Cache-Control: no-store` to all error responses (4xx/5xx) to prevent caching failures
- Introduces a `jsonWithCache()` helper to centralize header logic across all response paths

Closes #246

## Test plan
- [x] Test that successful 200 responses include `private` and `max-age=3600` in Cache-Control
- [x] Test that 400 error responses include `no-store` in Cache-Control
- [x] Test that validation error responses include `no-store` in Cache-Control
- [x] Test that successful responses include `stale-while-revalidate=60`

🤖 Generated with [Claude Code](https://claude.com/claude-code)