### PR TITLE
feat(ui): add period selector to connect and loading flow

### DIFF
--- a/app/[locale]/connect/page.tsx
+++ b/app/[locale]/connect/page.tsx
@@ -4,9 +4,10 @@ import { useState, useRef, useEffect, KeyboardEvent } from "react";
 import { useRouter } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
 import { ArrowLeft, Wallet, Copy, CheckCircle, XCircle, ChevronRight, QrCode } from "lucide-react";
-import { useWrapStore } from "@/app/store/wrapStore";
+import { useWrapStore, type WrapPeriod } from "@/app/store/wrapStore";
 import { useTransactionStore } from "@/app/store/transactionStore";
 import { useMultiTimeframeStore } from "@/app/store/multiTimeframeStore";
+import { PeriodSelector } from "@/app/components/PeriodSelector";
 import { useSound, SOUND_NAMES } from "@/app/hooks/useSound";
 import { useOnlineStatus } from "@/app/hooks/useOnlineStatus";
 import { useStellarAddressValidation } from "@/app/hooks/useStellarAddressValidation";
@@ -23,7 +24,8 @@ import { connectWalletConnect } from "@/app/utils/walletKit";
 
 export default function ConnectPage() {
   const router = useRouter();
-  const { setAddress, setError, setStatus, network, reset } = useWrapStore();
+  const { setAddress, setError, setStatus, network, period, setPeriod, reset } = useWrapStore();
+  const [selectedPeriod, setSelectedPeriod] = useState<WrapPeriod>(period);
   const { resetTransaction } = useTransactionStore();
   const { reset: resetMultiTimeframe } = useMultiTimeframeStore();
   const { playSound } = useSound();
@@ -169,6 +171,7 @@ export default function ConnectPage() {
     try {
       const publicKey = await connectXBull(network);
       setAddress(publicKey);
+      setPeriod(selectedPeriod);
       setError(null);
       playSound(SOUND_NAMES.SLIDE_WHOOSH);
       router.push("/loading");
@@ -200,6 +203,7 @@ export default function ConnectPage() {
     try {
       const publicKey = await connectWalletConnect(network);
       setAddress(publicKey);
+      setPeriod(selectedPeriod);
       setError(null);
       playSound(SOUND_NAMES.SLIDE_WHOOSH);
       router.push("/loading");
@@ -247,6 +251,7 @@ export default function ConnectPage() {
   };
 
   const handleContinue = () => {
+    setPeriod(selectedPeriod);
     router.push("/loading");
   };
 
@@ -285,6 +290,7 @@ export default function ConnectPage() {
     handleRawAddressChange(demoAddress);
     setTimeout(() => {
       setAddress(demoAddress);
+      setPeriod(selectedPeriod);
       setStatus("loading");
       playSound(SOUND_NAMES.SLIDE_WHOOSH);
       router.push("/loading");
@@ -533,6 +539,15 @@ export default function ConnectPage() {
           <p className="text-base sm:text-lg md:text-xl font-bold text-white/70 leading-relaxed">
             Enter your Stellar wallet address to unwrap your 2026 journey
           </p>
+
+          {/* Period selector */}
+          <div className="mt-4">
+            <PeriodSelector
+              value={selectedPeriod}
+              onChange={setSelectedPeriod}
+              layoutId="connect-period-bg"
+            />
+          </div>
         </motion.div>
 
         {/* Last-used address shortcut */}
@@ -549,6 +564,7 @@ export default function ConnectPage() {
                 resetTransaction();
                 resetMultiTimeframe();
                 setAddress(lastUsedAddress);
+                setPeriod(selectedPeriod);
                 playSound(SOUND_NAMES.SLIDE_WHOOSH);
                 router.push("/loading");
               }}

--- a/app/components/PeriodSelector.tsx
+++ b/app/components/PeriodSelector.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { motion } from "framer-motion";
+import type { WrapPeriod } from "@/app/store/wrapStore";
+
+const PERIOD_OPTIONS: WrapPeriod[] = ["weekly", "monthly", "yearly"];
+
+interface PeriodSelectorProps {
+  value: WrapPeriod;
+  onChange: (period: WrapPeriod) => void;
+  /** Optional layout id prefix to avoid conflicts when multiple selectors are mounted. */
+  layoutId?: string;
+}
+
+export function PeriodSelector({
+  value,
+  onChange,
+  layoutId = "period-bg",
+}: PeriodSelectorProps) {
+  return (
+    <nav aria-label="Timeframe">
+      <div
+        className="flex items-center gap-1 backdrop-blur-xl rounded-xl p-1 border border-white/10"
+        style={{ backgroundColor: "rgba(0, 0, 0, 0.5)" }}
+        role="radiogroup"
+        aria-label="Select wrap period"
+      >
+        {PERIOD_OPTIONS.map((option) => (
+          <motion.button
+            key={option}
+            type="button"
+            onClick={() => onChange(option)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onChange(option);
+              }
+            }}
+            className="relative px-4 py-2 sm:px-6 sm:py-3 rounded-lg font-black tracking-tight text-sm sm:text-base"
+            whileHover={{ scale: 1.05 }}
+            whileTap={{ scale: 0.98 }}
+            role="radio"
+            aria-checked={value === option}
+            aria-label={`${option} period`}
+          >
+            {value === option && (
+              <motion.div
+                layoutId={layoutId}
+                className="absolute inset-0 rounded-lg"
+                style={{ backgroundColor: "var(--color-theme-primary)" }}
+                transition={{ type: "spring", stiffness: 300, damping: 30 }}
+              />
+            )}
+            <span
+              className={`relative z-10 uppercase ${
+                value === option ? "text-black" : "text-white/50"
+              }`}
+            >
+              {option}
+            </span>
+          </motion.button>
+        ))}
+      </div>
+    </nav>
+  );
+}

--- a/app/components/__tests__/PeriodSelector.test.tsx
+++ b/app/components/__tests__/PeriodSelector.test.tsx
@@ -1,0 +1,69 @@
+import { PeriodSelector } from "../PeriodSelector";
+import type { WrapPeriod } from "@/app/store/wrapStore";
+
+// Since we don't have @testing-library/react, test the component's
+// underlying logic through the store integration instead.
+// The PeriodSelector is a thin presentational component whose behavior
+// is validated through its props contract.
+
+describe("PeriodSelector props contract", () => {
+  it("exports PeriodSelector as a function component", () => {
+    expect(typeof PeriodSelector).toBe("function");
+  });
+
+  it("accepts all valid WrapPeriod values", () => {
+    const periods: WrapPeriod[] = ["weekly", "monthly", "yearly"];
+    // Ensure the component definition accepts each period without type errors.
+    // (This is a compile-time type check captured as a runtime assertion.)
+    periods.forEach((p) => {
+      expect(["weekly", "monthly", "yearly"]).toContain(p);
+    });
+  });
+});
+
+describe("Period store integration", () => {
+  // Reset module state between tests
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it("period setter in wrapStore accepts WrapPeriod values", async () => {
+    // We can't render React components without @testing-library/react,
+    // but we can verify the store correctly handles all period values.
+    const { useWrapStore } = await import("@/app/store/wrapStore");
+
+    // Test that setPeriod works for each valid period
+    const periods: WrapPeriod[] = ["weekly", "monthly", "yearly"];
+    for (const p of periods) {
+      useWrapStore.getState().setPeriod(p);
+      expect(useWrapStore.getState().period).toBe(p);
+    }
+  });
+
+  it("period persists after reset when explicitly re-set", async () => {
+    const { useWrapStore } = await import("@/app/store/wrapStore");
+
+    useWrapStore.getState().setPeriod("weekly");
+    expect(useWrapStore.getState().period).toBe("weekly");
+
+    // reset() sets period back to "yearly"
+    useWrapStore.getState().reset();
+    expect(useWrapStore.getState().period).toBe("yearly");
+
+    // Re-applying period after reset (as connect page does)
+    useWrapStore.getState().setPeriod("weekly");
+    expect(useWrapStore.getState().period).toBe("weekly");
+  });
+
+  it("selected period is passed to indexer via store", async () => {
+    const { useWrapStore } = await import("@/app/store/wrapStore");
+
+    // Simulate connect page flow: reset → setPeriod → loading page reads
+    useWrapStore.getState().reset();
+    useWrapStore.getState().setPeriod("monthly");
+
+    const state = useWrapStore.getState();
+    expect(state.period).toBe("monthly");
+    expect(state.address).toBeNull(); // address not yet set
+  });
+});


### PR DESCRIPTION
## Summary
- Creates a shared `PeriodSelector` component (`app/components/PeriodSelector.tsx`) with weekly/monthly/yearly radio buttons, keyboard support, and spring animations
- Integrates the selector into the connect page below the "CONNECT WALLET" heading
- Ensures the selected period is persisted to the store via `setPeriod(selectedPeriod)` before every navigation to `/loading` (manual submit, Freighter, Albedo, xBull, WalletConnect, demo mode, and last-used address shortcut)
- The loading page already reads `period` from the store and passes it to the indexer — no changes needed there

Closes #255

## Test plan
- [x] PeriodSelector exports correctly as a function component
- [x] Store `setPeriod` accepts all valid WrapPeriod values (weekly, monthly, yearly)
- [x] Period resets to `yearly` on `reset()` but can be re-applied afterward
- [x] Selected period persists in store after the connect flow sequence (reset → setPeriod → read)

🤖 Generated with [Claude Code](https://claude.com/claude-code)