### PR TITLE
feat(ui): add progress recovery banner on app reload

### DIFF
--- a/app/components/ProgressRecoveryBanner.tsx
+++ b/app/components/ProgressRecoveryBanner.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useWrapStore } from "@/app/store/wrapStore";
+import type { PersistedIndexingState } from "@/app/types/indexing";
+
+const PERSISTENCE_KEY = "stellar-wrap-indexing-state";
+const PERSISTENCE_TIMEOUT = 5 * 60 * 1000; // 5 minutes
+
+export type RecoveryStatus = "resumable" | "expired" | "none";
+
+export interface PersistedSnapshot {
+  state: PersistedIndexingState;
+  status: RecoveryStatus;
+  ageMs: number;
+}
+
+/**
+ * Peek at the persisted indexing state without modifying it.
+ * Returns null when there is nothing stored or parsing fails.
+ */
+export function peekPersistedState(): PersistedSnapshot | null {
+  if (typeof window === "undefined") return null;
+
+  try {
+    const raw = localStorage.getItem(PERSISTENCE_KEY);
+    if (!raw) return null;
+
+    const state: PersistedIndexingState = JSON.parse(raw);
+    const ageMs = Date.now() - state.timestamp;
+    const status: RecoveryStatus =
+      ageMs > PERSISTENCE_TIMEOUT ? "expired" : "resumable";
+
+    return { state, status, ageMs };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Banner displayed on app reload when persisted indexing state is detected.
+ * Offers resume / restart / clear actions depending on whether the state
+ * is still within the persistence timeout window.
+ */
+export function ProgressRecoveryBanner() {
+  const router = useRouter();
+  const {
+    setAddress,
+    setPeriod,
+    setNetwork,
+    loadIndexingState,
+    clearPersistedIndexingState,
+    resetIndexing,
+  } = useWrapStore();
+
+  const [snapshot, setSnapshot] = useState<PersistedSnapshot | null>(null);
+
+  useEffect(() => {
+    setSnapshot(peekPersistedState());
+  }, []);
+
+  if (!snapshot) return null;
+
+  const { state, status } = snapshot;
+  const progressPct = state.overallProgress ?? 0;
+  const addressLabel = state.address
+    ? `${state.address.slice(0, 4)}...${state.address.slice(-4)}`
+    : "unknown";
+
+  const handleResume = () => {
+    // Restore store state so loadIndexingState can match address/network/period
+    if (state.address) setAddress(state.address);
+    if (state.network) setNetwork(state.network as "mainnet" | "testnet");
+    if (state.period && state.period !== "biweekly") {
+      setPeriod(state.period as "weekly" | "monthly" | "yearly");
+    }
+
+    const loaded = loadIndexingState();
+    if (loaded) {
+      router.push("/loading");
+    } else {
+      // State didn't match or expired — clear and dismiss
+      clearPersistedIndexingState();
+      setSnapshot(null);
+    }
+  };
+
+  const handleRestart = () => {
+    // Restore address/network/period but start indexing fresh
+    if (state.address) setAddress(state.address);
+    if (state.network) setNetwork(state.network as "mainnet" | "testnet");
+    if (state.period && state.period !== "biweekly") {
+      setPeriod(state.period as "weekly" | "monthly" | "yearly");
+    }
+    clearPersistedIndexingState();
+    setSnapshot(null);
+    router.push("/loading");
+  };
+
+  const handleClear = () => {
+    clearPersistedIndexingState();
+    resetIndexing();
+    setSnapshot(null);
+  };
+
+  return (
+    <div
+      role="alert"
+      data-testid="progress-recovery-banner"
+      className="fixed top-4 left-1/2 -translate-x-1/2 z-50 w-full max-w-lg px-4"
+    >
+      <div className="rounded-xl border border-white/15 bg-[#0d0d1a]/95 backdrop-blur-xl p-4 shadow-2xl shadow-black/50">
+        {/* Header */}
+        <div className="flex items-center gap-2 mb-3">
+          <div className="h-2 w-2 rounded-full bg-amber-400 animate-pulse" />
+          <h2 className="text-sm font-semibold text-white">
+            {status === "expired"
+              ? "Previous session expired"
+              : "Previous session found"}
+          </h2>
+        </div>
+
+        {/* Details */}
+        <p className="text-xs text-white/50 mb-3">
+          {status === "expired" ? (
+            <>
+              An indexing session for <span className="font-medium text-white/70">{addressLabel}</span> was
+              saved but has expired. You can restart or clear it.
+            </>
+          ) : (
+            <>
+              Indexing for <span className="font-medium text-white/70">{addressLabel}</span> was{" "}
+              <span className="font-medium text-white/70">{progressPct}%</span> complete
+              on <span className="font-medium text-white/70">{state.network}</span>.
+            </>
+          )}
+        </p>
+
+        {/* Progress bar */}
+        {status === "resumable" && (
+          <div className="h-1.5 w-full overflow-hidden rounded-full bg-white/10 mb-3">
+            <div
+              className="h-full rounded-full bg-gradient-to-r from-indigo-500 to-purple-500 transition-all duration-300"
+              style={{ width: `${progressPct}%` }}
+            />
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="flex items-center gap-2">
+          {status === "resumable" && (
+            <button
+              type="button"
+              onClick={handleResume}
+              className="flex-1 rounded-lg bg-indigo-500 px-3 py-2 text-xs font-medium text-white hover:bg-indigo-400 transition-colors"
+            >
+              Resume
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={handleRestart}
+            className="flex-1 rounded-lg border border-white/15 px-3 py-2 text-xs font-medium text-white/70 hover:bg-white/5 hover:text-white transition-colors"
+          >
+            Restart
+          </button>
+          <button
+            type="button"
+            onClick={handleClear}
+            className="rounded-lg px-3 py-2 text-xs font-medium text-white/40 hover:text-white/60 transition-colors"
+          >
+            Clear
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/__tests__/ProgressRecoveryBanner.test.ts
+++ b/app/components/__tests__/ProgressRecoveryBanner.test.ts
@@ -1,0 +1,171 @@
+import type { PersistedIndexingState } from "@/app/types/indexing";
+
+const PERSISTENCE_KEY = "stellar-wrap-indexing-state";
+const PERSISTENCE_TIMEOUT = 5 * 60 * 1000;
+
+function buildPersistedState(
+  overrides: Partial<PersistedIndexingState> = {},
+): PersistedIndexingState {
+  return {
+    currentStep: "fetching-transactions",
+    completedSteps: 2,
+    stepProgress: {
+      initializing: 100,
+      "fetching-transactions": 50,
+      "filtering-timeframes": 0,
+      "calculating-volume": 0,
+      "identifying-assets": 0,
+      "counting-contracts": 0,
+      finalizing: 0,
+    },
+    overallProgress: 30,
+    completedStepRecord: {
+      initializing: true,
+      "fetching-transactions": false,
+      "filtering-timeframes": false,
+      "calculating-volume": false,
+      "identifying-assets": false,
+      "counting-contracts": false,
+      finalizing: false,
+    },
+    stepTimings: {
+      initializing: 500,
+      "fetching-transactions": 0,
+      "filtering-timeframes": 0,
+      "calculating-volume": 0,
+      "identifying-assets": 0,
+      "counting-contracts": 0,
+      finalizing: 0,
+    },
+    startTime: Date.now() - 60_000,
+    timestamp: Date.now(),
+    address: "GDRZZGQDRBLJBAY24O3EMZFDGZ4EY6A7L24OERKQTPLT4T7SZKLUAZVQ",
+    network: "mainnet",
+    period: "monthly",
+    ...overrides,
+  };
+}
+
+// Mock localStorage and window for Node test environment
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+// Define window and localStorage for Node environment
+Object.defineProperty(globalThis, "window", {
+  value: globalThis,
+  writable: true,
+  configurable: true,
+});
+Object.defineProperty(globalThis, "localStorage", {
+  value: localStorageMock,
+  writable: true,
+  configurable: true,
+});
+
+// Import after window/localStorage are defined
+import {
+  peekPersistedState,
+} from "../ProgressRecoveryBanner";
+
+describe("peekPersistedState", () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+  });
+
+  it("returns null when nothing is stored", () => {
+    expect(peekPersistedState()).toBeNull();
+  });
+
+  it("returns null when stored value is invalid JSON", () => {
+    localStorageMock.setItem(PERSISTENCE_KEY, "not-json{{{");
+    expect(peekPersistedState()).toBeNull();
+  });
+
+  it('returns "resumable" for fresh state within timeout', () => {
+    const state = buildPersistedState({ timestamp: Date.now() });
+    localStorageMock.setItem(PERSISTENCE_KEY, JSON.stringify(state));
+
+    const snapshot = peekPersistedState();
+    expect(snapshot).not.toBeNull();
+    expect(snapshot!.status).toBe("resumable");
+    expect(snapshot!.state.overallProgress).toBe(30);
+    expect(snapshot!.ageMs).toBeLessThan(PERSISTENCE_TIMEOUT);
+  });
+
+  it('returns "expired" for state older than timeout', () => {
+    const state = buildPersistedState({
+      timestamp: Date.now() - PERSISTENCE_TIMEOUT - 1000,
+    });
+    localStorageMock.setItem(PERSISTENCE_KEY, JSON.stringify(state));
+
+    const snapshot = peekPersistedState();
+    expect(snapshot).not.toBeNull();
+    expect(snapshot!.status).toBe("expired");
+    expect(snapshot!.ageMs).toBeGreaterThan(PERSISTENCE_TIMEOUT);
+  });
+
+  it("preserves address from persisted state", () => {
+    const state = buildPersistedState({
+      address: "GTEST123456789012345678901234567890123456789012345",
+    });
+    localStorageMock.setItem(PERSISTENCE_KEY, JSON.stringify(state));
+
+    const snapshot = peekPersistedState();
+    expect(snapshot!.state.address).toBe(
+      "GTEST123456789012345678901234567890123456789012345",
+    );
+  });
+
+  it("preserves network from persisted state", () => {
+    const state = buildPersistedState({ network: "testnet" });
+    localStorageMock.setItem(PERSISTENCE_KEY, JSON.stringify(state));
+
+    const snapshot = peekPersistedState();
+    expect(snapshot!.state.network).toBe("testnet");
+  });
+
+  it("preserves period from persisted state", () => {
+    const state = buildPersistedState({ period: "weekly" });
+    localStorageMock.setItem(PERSISTENCE_KEY, JSON.stringify(state));
+
+    const snapshot = peekPersistedState();
+    expect(snapshot!.state.period).toBe("weekly");
+  });
+});
+
+describe("ProgressRecoveryBanner component", () => {
+  it("exports ProgressRecoveryBanner as a function component", async () => {
+    const mod = await import("../ProgressRecoveryBanner");
+    expect(typeof mod.ProgressRecoveryBanner).toBe("function");
+  });
+});
+
+describe("wrapStore clearPersistedIndexingState", () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+  });
+
+  it("removes persisted state from localStorage", async () => {
+    const state = buildPersistedState();
+    localStorageMock.setItem(PERSISTENCE_KEY, JSON.stringify(state));
+    expect(localStorageMock.getItem(PERSISTENCE_KEY)).not.toBeNull();
+
+    const { useWrapStore } = await import("@/app/store/wrapStore");
+    useWrapStore.getState().clearPersistedIndexingState();
+
+    expect(localStorageMock.getItem(PERSISTENCE_KEY)).toBeNull();
+  });
+});

--- a/app/loading/page.tsx
+++ b/app/loading/page.tsx
@@ -9,6 +9,7 @@ import { ProgressIndicator } from "../components/ProgressIndicator";
 import { StepProgressDisplay } from "../components/StepProgressDisplay";
 import { CacheStatusBadge } from "../components/CacheStatusBadge";
 import { MuteToggle } from "../components/MuteToggle";
+import { ProgressRecoveryBanner } from "../components/ProgressRecoveryBanner";
 import { useWrapStore, type WrapResult } from "../store/wrapStore";
 
 import { useSound } from "../hooks/useSound";
@@ -242,6 +243,7 @@ export default function LoadingScreen() {
 
   return (
     <div className="relative w-full min-h-screen h-screen overflow-hidden flex items-center justify-center bg-theme-background">
+      <ProgressRecoveryBanner />
       <ProgressIndicator currentStep={3} totalSteps={6} showNext={false} />
 
       {/* Container for centered layout with progress left and content right */}


### PR DESCRIPTION
## Summary
- Creates `ProgressRecoveryBanner` component (`app/components/ProgressRecoveryBanner.tsx`) that detects persisted indexing state on page load
- Shows a fixed top banner with account details and progress percentage when a previous session is found
- Differentiates between **resumable** sessions (within 5-minute timeout) with a Resume button, and **expired** sessions
- Provides three actions: **Resume** (restores store state and navigates to loading), **Restart** (fresh indexing for same account), and **Clear** (dismisses and removes persisted state)
- Exports `peekPersistedState()` utility for inspecting localStorage without side effects
- Integrates the banner into the loading page (`app/loading/page.tsx`)

Closes #261

## Test plan
- [x] `peekPersistedState` returns null when nothing is stored
- [x] Returns null for invalid JSON in localStorage
- [x] Returns `resumable` status for fresh state within 5-minute timeout
- [x] Returns `expired` status for state older than timeout
- [x] Preserves address, network, and period from persisted state
- [x] `clearPersistedIndexingState` removes the persisted state from localStorage
- [x] Component exports correctly as a function

🤖 Generated with [Claude Code](https://claude.com/claude-code)