### PR TITLE
feat(vibe-check): surface NFT activity (mint count + top creator) on …

### DIFF
--- a/app/components/Screen4VibeCheck.tsx
+++ b/app/components/Screen4VibeCheck.tsx
@@ -2,14 +2,14 @@
 
 import { motion } from 'framer-motion';
 import { useMemo } from 'react';
-import { TrendingUp, Palette, Code } from 'lucide-react';
+import { TrendingUp, Palette, Code, Sparkles, Crown } from 'lucide-react';
 import { formatDappDisplayName } from '@/app/utils/formatDappLabel';
 import { DappIcon } from '@/app/components/DappIcon';
 import { DexTradingSummary } from './DexTradingSummary';
 import { SorobanBuilderTimeline } from './SorobanBuilderTimeline';
 import { PortfolioDiversityCard } from './PortfolioDiversityCard';
 import { BiggestDayCard } from './BiggestDayCard';
-import type { DexTradingSummary as DexTradingSummaryType, SorobanBuilderSummary as SorobanBuilderSummaryType, PortfolioDiversitySummary, BiggestDaySummary } from '@/app/utils/indexer';
+import type { DexTradingSummary as DexTradingSummaryType, SorobanBuilderSummary as SorobanBuilderSummaryType, PortfolioDiversitySummary, BiggestDaySummary, NftActivitySummary } from '@/app/utils/indexer';
 
 type VibeIconKey = 'defi' | 'nft' | 'dev';
 
@@ -34,23 +34,118 @@ interface Screen4VibeCheckProps {
   sorobanBuilderSummary?: SorobanBuilderSummaryType;
   portfolioDiversitySummary?: PortfolioDiversitySummary;
   biggestDaySummary?: BiggestDaySummary;
+  nftActivitySummary?: NftActivitySummary;
 }
 
 const TOP_DAPPS_LIMIT = 5;
 
-// Icon mapping for different vibe types
 const vibeIcons: Record<VibeIconKey, React.ComponentType<{ className?: string }>> = {
   defi: TrendingUp,
   nft: Palette,
   dev: Code,
 };
 
-export function Screen4VibeCheck({ vibes, dapps = [], dexTradingSummary, sorobanBuilderSummary, portfolioDiversitySummary, biggestDaySummary }: Screen4VibeCheckProps) {
+function shortenAddress(address: string): string {
+  if (address.length <= 10) return address;
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+}
+
+function NftActivityCard({ summary }: { summary?: NftActivitySummary }) {
+  if (!summary || summary.mintCount === 0) return null;
+
+  const hasTopCreator = summary.topCreatorAddress && summary.topCreatorMintCount > 0;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: 0.9, type: "spring", stiffness: 120 }}
+      className="mt-8 sm:mt-10 md:mt-12"
+    >
+      <h3 className="text-xs sm:text-sm font-black tracking-[0.25em] text-white/50 mb-3 sm:mb-4">
+        NFT ACTIVITY
+      </h3>
+      <div
+        className="p-5 sm:p-6 md:p-8 rounded-2xl sm:rounded-3xl border border-white/10 backdrop-blur-md relative overflow-hidden"
+        style={{ backgroundColor: "rgba(255, 255, 255, 0.03)" }}
+      >
+        <div className="flex flex-col gap-5 sm:gap-6">
+          <div className="flex items-center gap-4 sm:gap-5">
+            <motion.div
+              className="w-14 h-14 sm:w-16 sm:h-16 rounded-2xl flex items-center justify-center flex-shrink-0"
+              style={{ backgroundColor: 'var(--color-theme-primary)' }}
+              animate={{
+                boxShadow: [
+                  `0 0 15px rgba(var(--color-theme-primary-rgb), 0.3)`,
+                  `0 0 30px rgba(var(--color-theme-primary-rgb), 0.5)`,
+                  `0 0 15px rgba(var(--color-theme-primary-rgb), 0.3)`,
+                ],
+              }}
+              transition={{ duration: 2.5, repeat: Infinity }}
+            >
+              <Sparkles className="w-7 h-7 sm:w-8 sm:h-8 text-black" />
+            </motion.div>
+            <div>
+              <p className="text-xs sm:text-sm font-semibold text-white/50 uppercase tracking-wider mb-1">
+                Mints Collected
+              </p>
+              <motion.span
+                className="text-4xl sm:text-5xl md:text-6xl font-black text-white block leading-none"
+                initial={{ scale: 0 }}
+                animate={{ scale: 1 }}
+                transition={{ delay: 1, type: "spring", stiffness: 200 }}
+              >
+                {summary.mintCount.toLocaleString()}
+              </motion.span>
+            </div>
+          </div>
+
+          {hasTopCreator && (
+            <div className="pt-4 sm:pt-5 border-t border-white/10">
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex items-center gap-3 min-w-0">
+                  <div className="w-10 h-10 sm:w-12 sm:h-12 rounded-xl border-2 border-white/20 flex items-center justify-center flex-shrink-0"
+                    style={{ backgroundColor: 'rgba(var(--color-theme-primary-rgb), 0.15)' }}
+                  >
+                    <Crown className="w-5 h-5 sm:w-6 sm:h-6 text-theme-primary" />
+                  </div>
+                  <div className="min-w-0">
+                    <p className="text-xs font-semibold text-white/40 uppercase tracking-wider mb-0.5">
+                      Top Creator
+                    </p>
+                    <p
+                      className="text-base sm:text-lg font-bold text-white truncate font-mono"
+                      title={summary.topCreatorAddress ?? undefined}
+                    >
+                      {shortenAddress(summary.topCreatorAddress!)}
+                    </p>
+                  </div>
+                </div>
+                <div className="text-right shrink-0">
+                  <p className="text-xs font-semibold text-white/40 uppercase tracking-wider mb-0.5">
+                    Mints
+                  </p>
+                  <p className="text-xl sm:text-2xl font-black text-white/80 tabular-nums">
+                    {summary.topCreatorMintCount}
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </motion.div>
+  );
+}
+
 export function Screen4VibeCheck({
   vibes,
   dapps = [],
-  dailyActivity = {},
-  period = "monthly",
+  dexTradingSummary,
+  sorobanBuilderSummary,
+  portfolioDiversitySummary,
+  biggestDaySummary,
+  nftActivitySummary,
 }: Screen4VibeCheckProps) {
   const topDapps = useMemo(
     () => [...dapps].sort((a, b) => b.interactions - a.interactions).slice(0, TOP_DAPPS_LIMIT),
@@ -246,9 +341,11 @@ export function Screen4VibeCheck({
             )}
 
             <PortfolioDiversityCard summary={portfolioDiversitySummary} />
+            <NftActivityCard summary={nftActivitySummary} />
             <BiggestDayCard summary={biggestDaySummary} />
             <DexTradingSummary summary={dexTradingSummary} />
             <SorobanBuilderTimeline summary={sorobanBuilderSummary} />
+            </div>
           </div>
 
           {/* Right: Visualization */}

--- a/app/services/achievementCalculator.ts
+++ b/app/services/achievementCalculator.ts
@@ -7,7 +7,12 @@
  * Groups transactions by timeframe for analysis
  */
 
-import { IndexerResult, DappInfo, VibeTag, DexTradingSummary, SorobanDeployment, SorobanBuilderSummary } from "@/app/utils/indexer";
+import { IndexerResult, DappInfo, VibeTag, DexTradingSummary, SorobanDeployment, SorobanBuilderSummary, NftActivitySummary, PortfolioDiversitySummary, BiggestDaySummary, TopAsset } from "@/app/utils/indexer";
+
+interface DailyStats {
+  txCount: number;
+  categories: Record<string, number>;
+}
 
 /**
  * Raw transaction from Horizon API
@@ -184,6 +189,11 @@ export function calculateAchievements(
       dapps: [],
       vibes: [{ tag: "Getting Started", count: 0 }],
       persona: "The Explorer",
+      nftActivitySummary: {
+        mintCount: 0,
+        topCreatorAddress: null,
+        topCreatorMintCount: 0,
+      },
       dexTradingSummary: {
         totalVolume: 0,
         tradeCount: 0,
@@ -209,13 +219,14 @@ export function calculateAchievements(
         topActivity: "None",
         tagline: "A chill day on Stellar",
         busiestDayOfWeek: "None",
-      }
+      },
     };
   }
 
   // Initialize trackers
   let totalVolume = 0;
   let totalGasSpent = 0;
+  let successfulTxCount = 0;
   const assetMap = new Map<string, number>(); // asset -> operation count
   const assetVolumeMap = new Map<string, number>(); // asset -> total volume
   const dappMap = new Map<string, DappInfo>();
@@ -248,9 +259,13 @@ export function calculateAchievements(
   const personaMetrics: PersonaMetrics = {
     dexOpCount: 0,       // offers + path payments
     lpTrustlineCount: 0, // change_trust with non-native assets (LP tokens)
-    totalTransactions: transactions.length,
+    totalTransactions: 0,
     contractCalls: 0,
   };
+
+  // NFT activity trackers
+  let nftMintCount = 0;
+  const nftCreatorMap = new Map<string, number>(); // creator address -> mint count
 
   // Additional metrics tracking
   let largestTransaction = 0;
@@ -264,7 +279,8 @@ export function calculateAchievements(
   transactions.forEach((tx: Transaction) => {
     // Skip invalid or failed transactions
     if (tx.successful === false) return;
-    if (!tx.operations || tx.operations.length === 0) return;
+    successfulTxCount++;
+    personaMetrics.totalTransactions = successfulTxCount;
 
     // Track gas spent
     if (tx.fee_charged) {
@@ -280,6 +296,8 @@ export function calculateAchievements(
     const dayStat = dailyStats.get(txDate)!;
     dayStat.txCount++;
     dayOfWeekCount[dateObj.getDay()]++;
+
+    if (!tx.operations || tx.operations.length === 0) return;
 
     // Process each operation in the transaction
     tx.operations.forEach((op: Operation) => {
@@ -297,21 +315,43 @@ export function calculateAchievements(
         case "path_payment_strict_receive":
         case "path_payment_strict_send":
           categories.swaps++;
+          dayStat.categories.swaps = (dayStat.categories.swaps || 0) + 1;
           processPathPaymentOperation(op, assetMap, assetVolumeMap, vibeMap, dexTrackers);
+          personaMetrics.dexOpCount++;
           break;
 
-        case "invoke_host_function":
+        case "invoke_host_function": {
           categories.contractCalls++;
           personaMetrics.contractCalls++;
-          // Check if this is a contract deployment (HostFunctionTypeCreateContract)
-          // We'll assume the function field or asset/contract field indicates deployment
+          dayStat.categories.contractCalls = (dayStat.categories.contractCalls || 0) + 1;
+          // Detect deployment: no explicit function call, or create/wasm keywords in function
+          const fnName = (op.function || "").toLowerCase();
+          const isDeployment =
+            !op.function ||
+            fnName.includes("create") ||
+            fnName.includes("deploy") ||
+            fnName.includes("wasm");
           processContractOperation(op, dappMap, isDeployment, sorobanTrackers, tx);
           if (isDeployment) {
-            vibeMap.set("soroban-user", (vibeMap.get("soroban-user") || 0) + 5); // Boost for deployments
+            vibeMap.set("soroban-user", (vibeMap.get("soroban-user") || 0) + 5);
           } else {
             vibeMap.set("soroban-user", (vibeMap.get("soroban-user") || 0) + 1);
           }
+          // Detect NFT mint operations via Soroban (mint / mint_to / mint_wrap / create_nft)
+          const isNftMint =
+            fnName.includes("mint") ||
+            fnName.includes("create_nft") ||
+            fnName.includes("nft_mint");
+          if (isNftMint) {
+            nftMintCount++;
+            const creator = op.contract_id || op.contract || op.from || "";
+            if (creator) {
+              nftCreatorMap.set(creator, (nftCreatorMap.get(creator) || 0) + 1);
+            }
+            vibeMap.set("nft-collector", (vibeMap.get("nft-collector") || 0) + 1);
+          }
           break;
+        }
 
         case "extend_footprint_ttl":
         case "restore_footprint":
@@ -325,14 +365,35 @@ export function calculateAchievements(
         case "manage_sell_offer":
         case "create_passive_sell_offer":
           categories.offers++;
-          processOfferOperation(op, assetMap, vibeMap, dexTrackers);
+          dayStat.categories.offers = (dayStat.categories.offers || 0) + 1;
+          processOfferOperation(op, assetMap, assetVolumeMap, vibeMap, dexTrackers);
+          personaMetrics.dexOpCount++;
           break;
 
         case "change_trust":
         case "allow_trust":
-        case "set_trust_line_flags":
+        case "set_trust_line_flags": {
           categories.trustlines++;
+          dayStat.categories.trustlines = (dayStat.categories.trustlines || 0) + 1;
+          // Detect potential NFT collection: trustline to a non-native, non-LP asset
+          const asset = op.asset_code;
+          const issuer = op.asset_issuer;
+          if (asset && issuer && asset.toUpperCase() !== "XLM") {
+            // Count unique trustlines to issuers as potential NFT collections
+            // Skip common LP / pool tokens
+            const isLikelyLP =
+              asset.toLowerCase().includes("lp") ||
+              asset.toLowerCase().includes("pool");
+            if (!isLikelyLP) {
+              nftMintCount++;
+              nftCreatorMap.set(issuer, (nftCreatorMap.get(issuer) || 0) + 1);
+              vibeMap.set("nft-collector", (vibeMap.get("nft-collector") || 0) + 1);
+            } else {
+              personaMetrics.lpTrustlineCount++;
+            }
+          }
           break;
+        }
 
         default:
           categories.other++;
@@ -354,29 +415,60 @@ export function calculateAchievements(
     totalVolume += volume;
   });
 
-  // Determine most active asset by operation count
+  // Determine most active asset by total volume, fallback to operation count when tied
   let mostActiveAsset = "XLM";
+  let maxVolume = 0;
   let maxCount = 0;
-  assetMap.forEach((count, asset) => {
-    if (count > maxCount) {
-      maxCount = count;
+  assetVolumeMap.forEach((volume, asset) => {
+    const opCount = assetMap.get(asset) || 0;
+    if (volume > maxVolume || (volume === maxVolume && opCount > maxCount)) {
+      maxVolume = volume;
+      maxCount = opCount;
       mostActiveAsset = asset;
     }
   });
+  // Fallback: if no volumes tracked, use operation count ranking
+  if (maxVolume === 0) {
+    assetMap.forEach((count, asset) => {
+      if (count > maxCount) {
+        maxCount = count;
+        mostActiveAsset = asset;
+      }
+    });
+  }
 
   // Generate vibe tags based on activity patterns
   const vibes = generateVibes(
-    transactions.length,
+    successfulTxCount,
     totalVolume,
     categories.contractCalls,
     vibeMap,
     assetMap,
   );
 
+  // Determine persona archetype
+  const defiTraderCount = vibeMap.get("defi-trader") || 0;
+  const deploymentCount = sorobanTrackers.deployments.length;
+  const persona = assignPersona({
+    categories,
+    deploymentCount,
+    contractCallCount: categories.contractCalls,
+    defiTraderCount,
+    dexTradeCount: dexTrackers.tradeCount,
+    totalVolume,
+    txCount: successfulTxCount,
+  });
+
+  // Build summaries
+  const dexTradingSummary = buildDexTradingSummary(dexTrackers);
+  const sorobanBuilderSummary = buildSorobanBuilderSummary(sorobanTrackers);
+  const nftActivitySummary = buildNftActivitySummary(nftMintCount, nftCreatorMap);
+  const portfolioDiversitySummary = buildPortfolioDiversitySummary(assetMap, assetVolumeMap, totalVolume);
+  const biggestDaySummary = buildBiggestDaySummary(dailyStats, dayOfWeekCount);
 
   return {
     accountId: "",
-    totalTransactions: transactions.length,
+    totalTransactions: successfulTxCount,
     totalVolume,
     mostActiveAsset,
     contractCalls: categories.contractCalls,
@@ -386,6 +478,12 @@ export function calculateAchievements(
     ),
     vibes,
     persona,
+    nftActivitySummary,
+    dexTradingSummary,
+    sorobanBuilderSummary,
+    portfolioDiversitySummary,
+    biggestDaySummary,
+    largestTransaction: largestTransaction > 0 ? { amount: largestTransaction, assetCode: largestTransactionAsset } : undefined,
   };
 }
 
@@ -479,20 +577,40 @@ function processPathPaymentOperation(
 ): void {
   const sourceAmount = op.source_amount ? parseFloat(op.source_amount) : 0;
   const destAmount = op.destination_amount ? parseFloat(op.destination_amount) : 0;
+  const plainAmount = op.amount ? parseFloat(op.amount) : 0;
   const sourceAsset = op.source_asset_code || "XLM";
   const destAsset = op.destination_asset_code || "XLM";
+  const plainAsset = op.asset_code;
 
-  // Track both assets involved in swap
-  assetMap.set(sourceAsset, (assetMap.get(sourceAsset) || 0) + 1);
-  assetMap.set(destAsset, (assetMap.get(destAsset) || 0) + 1);
-  assetVolumeMap.set(sourceAsset, (assetVolumeMap.get(sourceAsset) || 0) + sourceAmount);
-  assetVolumeMap.set(destAsset, (assetVolumeMap.get(destAsset) || 0) + destAmount);
+  const hasSpecificAmounts = sourceAmount > 0 || destAmount > 0;
+  const singleAsset = plainAsset || sourceAsset || destAsset;
 
-  // Track DEX summary
+  if (hasSpecificAmounts) {
+    assetMap.set(sourceAsset, (assetMap.get(sourceAsset) || 0) + 1);
+    assetMap.set(destAsset, (assetMap.get(destAsset) || 0) + 1);
+    if (sourceAmount > 0) {
+      assetVolumeMap.set(sourceAsset, (assetVolumeMap.get(sourceAsset) || 0) + sourceAmount);
+    }
+    if (destAmount > 0) {
+      assetVolumeMap.set(destAsset, (assetVolumeMap.get(destAsset) || 0) + destAmount);
+    }
+  } else if (plainAmount > 0) {
+    assetMap.set(singleAsset, (assetMap.get(singleAsset) || 0) + 1);
+    assetVolumeMap.set(singleAsset, (assetVolumeMap.get(singleAsset) || 0) + plainAmount);
+  } else {
+    assetMap.set(sourceAsset, (assetMap.get(sourceAsset) || 0) + 1);
+    assetMap.set(destAsset, (assetMap.get(destAsset) || 0) + 1);
+  }
+
   const pair = [sourceAsset, destAsset].sort().join("/");
   dexTrackers.pairMap.set(pair, (dexTrackers.pairMap.get(pair) || 0) + 1);
-  // For simplicity, we'll use sourceAmount as part of volume (assume source asset is XLM if possible)
-  dexTrackers.totalVolume += sourceAmount;
+  if (sourceAmount > 0) {
+    dexTrackers.totalVolume += sourceAmount;
+  } else if (plainAmount > 0) {
+    dexTrackers.totalVolume += plainAmount;
+  } else {
+    dexTrackers.totalVolume += destAmount;
+  }
   dexTrackers.tradeCount += 1;
   dexTrackers.buyCount += 1;
   dexTrackers.sellCount += 1;
@@ -506,21 +624,24 @@ function processPathPaymentOperation(
 function processOfferOperation(
   op: Operation,
   assetMap: Map<string, number>,
+  assetVolumeMap: Map<string, number>,
   vibeMap: Map<string, number>,
   dexTrackers: { totalVolume: number; tradeCount: number; buyCount: number; sellCount: number; pairMap: Map<string, number> },
 ): void {
   const asset = op.asset_code || "XLM";
+  const amount = op.amount ? parseFloat(op.amount) : 0;
   assetMap.set(asset, (assetMap.get(asset) || 0) + 1);
+  assetVolumeMap.set(asset, (assetVolumeMap.get(asset) || 0) + amount);
   vibeMap.set("defi-trader", (vibeMap.get("defi-trader") || 0) + 1);
 
   // Track DEX summary
   dexTrackers.tradeCount += 1;
+  dexTrackers.totalVolume += amount;
   if (op.type === "manage_buy_offer") {
     dexTrackers.buyCount += 1;
   } else {
     dexTrackers.sellCount += 1;
   }
-  // Since we don't have counter asset or price data for offers, skip volume and pair tracking for now
 }
 
 /**
@@ -610,6 +731,138 @@ function buildSorobanBuilderSummary(
     deploymentCount,
     contractCallCount,
     builderScore,
+  };
+}
+
+function buildNftActivitySummary(
+  mintCount: number,
+  creatorMap: Map<string, number>,
+): NftActivitySummary {
+  let topCreatorAddress: string | null = null;
+  let topCreatorMintCount = 0;
+
+  creatorMap.forEach((count, address) => {
+    if (count > topCreatorMintCount) {
+      topCreatorMintCount = count;
+      topCreatorAddress = address;
+    }
+  });
+
+  return {
+    mintCount,
+    topCreatorAddress,
+    topCreatorMintCount,
+  };
+}
+
+function buildPortfolioDiversitySummary(
+  assetMap: Map<string, number>,
+  assetVolumeMap: Map<string, number>,
+  totalVolume: number,
+): PortfolioDiversitySummary {
+  const uniqueAssetsCount = assetMap.size;
+
+  let score = 0;
+  let label = "Mono-asset";
+  if (uniqueAssetsCount >= 10) {
+    score = 95;
+    label = "Rainbow Collector";
+  } else if (uniqueAssetsCount >= 6) {
+    score = 75;
+    label = "Diversified";
+  } else if (uniqueAssetsCount >= 3) {
+    score = 50;
+    label = "Multi-asset";
+  } else if (uniqueAssetsCount >= 2) {
+    score = 25;
+    label = "Bi-asset";
+  }
+
+  const topAssets: TopAsset[] = [];
+  if (totalVolume > 0) {
+    const sortedByVolume = Array.from(assetVolumeMap.entries()).sort(
+      (a, b) => b[1] - a[1],
+    );
+    for (let i = 0; i < Math.min(5, sortedByVolume.length); i++) {
+      const [asset, vol] = sortedByVolume[i];
+      const percentage = Math.round((vol / totalVolume) * 100) || 1;
+      topAssets.push({ assetCode: asset, percentage });
+    }
+  }
+
+  return {
+    score,
+    label,
+    uniqueAssetsCount,
+    topAssets,
+  };
+}
+
+function buildBiggestDaySummary(
+  dailyStats: Map<string, DailyStats>,
+  dayOfWeekCount: number[],
+): BiggestDaySummary {
+  let biggestDate = "";
+  let biggestTxCount = 0;
+  let biggestBreakdown: Record<string, number> = {};
+
+  dailyStats.forEach((stat, date) => {
+    if (stat.txCount > biggestTxCount) {
+      biggestTxCount = stat.txCount;
+      biggestDate = date;
+      biggestBreakdown = stat.categories;
+    }
+  });
+
+  const DAYS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+  let busiestDayOfWeek = "None";
+  let maxDay = 0;
+  for (let i = 0; i < 7; i++) {
+    if (dayOfWeekCount[i] > maxDay) {
+      maxDay = dayOfWeekCount[i];
+      busiestDayOfWeek = DAYS[i];
+    }
+  }
+
+  let topActivity = "None";
+  let maxCat = 0;
+  Object.entries(biggestBreakdown).forEach(([key, val]) => {
+    if (val > maxCat) {
+      maxCat = val;
+      topActivity = key;
+    }
+  });
+
+  const activityLabels: Record<string, string> = {
+    payments: "Payments",
+    swaps: "Swaps",
+    offers: "DEX Offers",
+    contractCalls: "Contract Calls",
+    trustlines: "Trustlines",
+    other: "Other",
+  };
+  const topActivityLabel = activityLabels[topActivity] || "Mixed Activity";
+
+  const taglines = [
+    "A wild day on-chain",
+    "You were cooking 🔥",
+    "Peak Stellar activity",
+    "The day you went ham",
+  ];
+  const tagline =
+    biggestTxCount > 20
+      ? taglines[Math.floor(Math.random() * taglines.length)]
+      : biggestTxCount > 5
+      ? "A productive day on Stellar"
+      : "A chill day on Stellar";
+
+  return {
+    date: biggestDate,
+    transactionCount: biggestTxCount,
+    typeBreakdown: biggestBreakdown,
+    topActivity: topActivityLabel,
+    tagline,
+    busiestDayOfWeek,
   };
 }
 

--- a/app/store/wrapStore.ts
+++ b/app/store/wrapStore.ts
@@ -44,7 +44,7 @@ export interface VibeSlice {
   label: string;
 }
 
-import type { DexTradingSummary as DexTradingSummaryType, SorobanBuilderSummary as SorobanBuilderSummaryType, PortfolioDiversitySummary as PortfolioDiversitySummaryType, BiggestDaySummary as BiggestDaySummaryType } from "@/app/utils/indexer";
+import type { DexTradingSummary as DexTradingSummaryType, SorobanBuilderSummary as SorobanBuilderSummaryType, PortfolioDiversitySummary as PortfolioDiversitySummaryType, BiggestDaySummary as BiggestDaySummaryType, NftActivitySummary as NftActivitySummaryType } from "@/app/utils/indexer";
 
 export interface WrapResult {
   username: string;
@@ -58,6 +58,8 @@ export interface WrapResult {
   sorobanBuilderSummary?: SorobanBuilderSummaryType;
   portfolioDiversitySummary?: PortfolioDiversitySummaryType;
   biggestDaySummary?: BiggestDaySummaryType;
+  nftActivitySummary?: NftActivitySummaryType;
+  largestTransaction?: { amount: number; assetCode: string };
 }
 
 type WrapStatus = "idle" | "loading" | "ready" | "error";

--- a/app/utils/indexer.ts
+++ b/app/utils/indexer.ts
@@ -58,6 +58,12 @@ export interface BiggestDaySummary {
   busiestDayOfWeek: string;
 }
 
+export interface NftActivitySummary {
+  mintCount: number;
+  topCreatorAddress: string | null;
+  topCreatorMintCount: number;
+}
+
 export interface IndexerResult {
   accountId: string;
   totalTransactions: number;
@@ -67,6 +73,12 @@ export interface IndexerResult {
   gasSpent: number;
   dapps: DappInfo[];
   vibes: VibeTag[];
+  nftActivitySummary?: NftActivitySummary;
+  dexTradingSummary?: DexTradingSummary;
+  sorobanBuilderSummary?: SorobanBuilderSummary;
+  portfolioDiversitySummary?: PortfolioDiversitySummary;
+  biggestDaySummary?: BiggestDaySummary;
+  largestTransaction?: { amount: number; assetCode: string };
   /**
    * Computed persona archetype for this account, e.g. "The Yield Farmer".
    * Assigned by detectPersona() in achievementCalculator.

--- a/app/utils/wrapResultMapper.ts
+++ b/app/utils/wrapResultMapper.ts
@@ -39,6 +39,7 @@ export function mapIndexerResultToWrapResult(
     biggestDaySummary: indexerResult.biggestDaySummary,
     dexTradingSummary: indexerResult.dexTradingSummary,
     sorobanBuilderSummary: indexerResult.sorobanBuilderSummary,
+    nftActivitySummary: indexerResult.nftActivitySummary,
     largestTransaction: indexerResult.largestTransaction,
   };
 }

--- a/app/vibe-check/Page.tsx
+++ b/app/vibe-check/Page.tsx
@@ -18,10 +18,11 @@ export default function VibeCheckPage() {
   const sorobanBuilderSummary = result?.sorobanBuilderSummary;
   const portfolioDiversitySummary = result?.portfolioDiversitySummary;
   const biggestDaySummary = result?.biggestDaySummary;
+  const nftActivitySummary = result?.nftActivitySummary;
 
   return (
     <div className="relative w-full h-screen">
-      <Screen4VibeCheck vibes={vibes} dapps={dapps} dexTradingSummary={dexTradingSummary} sorobanBuilderSummary={sorobanBuilderSummary} portfolioDiversitySummary={portfolioDiversitySummary} biggestDaySummary={biggestDaySummary} />
+      <Screen4VibeCheck vibes={vibes} dapps={dapps} dexTradingSummary={dexTradingSummary} sorobanBuilderSummary={sorobanBuilderSummary} portfolioDiversitySummary={portfolioDiversitySummary} biggestDaySummary={biggestDaySummary} nftActivitySummary={nftActivitySummary} />
 
       <ProgressIndicator
         currentStep={4}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,10 +46,10 @@ importers:
         version: 12.29.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next:
         specifier: ^16.1.4
-        version: 16.1.4(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.1.4(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.62.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-intl:
         specifier: ^4.13.0
-        version: 4.13.0(next@16.1.4(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@5.9.3)
+        version: 4.13.0(next@16.1.4(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.62.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@5.9.3)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -72,6 +72,9 @@ importers:
         specifier: ^5.0.10
         version: 5.0.10(@types/react@19.2.10)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.62.0
       '@types/canvas-confetti':
         specifier: ^1.9.0
         version: 1.9.0
@@ -93,6 +96,9 @@ importers:
       ansi-styles:
         specifier: ^6.2.1
         version: 6.2.3
+      autocannon:
+        specifier: 7.15.0
+        version: 7.15.0
       eslint:
         specifier: ^9
         version: 9.39.2(jiti@2.6.1)
@@ -205,6 +211,9 @@ packages:
 
   '@albedo-link/intent@0.12.0':
     resolution: {integrity: sha512-UlGBhi0qASDYOjLrOL4484vQ26Ee3zTK2oAgvPMClOs+1XNk3zbs3dECKZv+wqeSI8SkHow8mXLTa16eVh+dQA==}
+
+  '@assemblyscript/loader@0.19.23':
+    resolution: {integrity: sha512-ulkCYfFbYj01ie1MDOyxv2F6SpRN1TOj7fQxbP07D6HmeR+gr2JLSmINKjga2emB+b1L2KGrFKBTc+e00p54nw==}
 
   '@babel/code-frame@7.28.6':
     resolution: {integrity: sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==}
@@ -374,6 +383,10 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@colors/colors@1.5.0':
+    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
+    engines: {node: '>=0.1.90'}
 
   '@creit.tech/xbull-wallet-connect@0.4.0':
     resolution: {integrity: sha512-LrCUIqUz50SkZ4mv2hTqSmwews8CNRYVoZ9+VjLsK/1U8PByzXTxv1vZyenj6avRTG86ifpoeihz7D3D5YIDrQ==}
@@ -1013,6 +1026,11 @@ packages:
 
   '@phosphor-icons/webcomponents@2.1.5':
     resolution: {integrity: sha512-JcvQkZxvcX2jK+QCclm8+e8HXqtdFW9xV4/kk2aL9Y3dJA2oQVt+pzbv1orkumz3rfx4K9mn9fDoMr1He1yr7Q==}
+
+  '@playwright/test@1.62.0':
+    resolution: {integrity: sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -2313,6 +2331,10 @@ packages:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
 
+  autocannon@7.15.0:
+    resolution: {integrity: sha512-NaP2rQyA+tcubOJMFv2+oeW9jv2pq/t+LM6BL3cfJic0HEfscEcnWgAyU5YovE/oTHUzAgTliGdLPR+RQAWUbg==}
+    hasBin: true
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -2507,6 +2529,9 @@ packages:
   buffer-xor@1.0.3:
     resolution: {integrity: sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==}
 
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
@@ -2570,6 +2595,9 @@ packages:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
     engines: {node: '>=10'}
 
+  char-spinner@1.0.1:
+    resolution: {integrity: sha512-acv43vqJ0+N0rD+Uw3pDHSxP30FHrywu2NO6/wBaHChJIizpDeBUd6NjqhNhy9LGaEAhZAXn46QzmlAvIWd16g==}
+
   charenc@0.0.2:
     resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
 
@@ -2587,6 +2615,10 @@ packages:
 
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+
+  cli-table3@0.6.5:
+    resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
+    engines: {node: 10.* || >= 12.*}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
@@ -2615,6 +2647,10 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  color-support@1.1.3:
+    resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
+    hasBin: true
 
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -2656,6 +2692,9 @@ packages:
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
+
+  cross-argv@2.0.0:
+    resolution: {integrity: sha512-YIaY9TR5Nxeb8SMdtrU8asWVM4jqJDNDYlKV21LxtYcfNJhp1kEsgSa6qXwXgzN0WQWGODps0+TlGp2xQSHwOg==}
 
   cross-fetch@3.2.0:
     resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
@@ -3203,6 +3242,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3301,6 +3345,9 @@ packages:
     engines: {node: '>=0.4.7'}
     hasBin: true
 
+  has-async-hooks@1.0.0:
+    resolution: {integrity: sha512-YF0VPGjkxr7AyyQQNykX8zK4PvtEDsUJAPqwu06UFz1lb6EvI53sPh5H1kWxg8NXI5LsfRCZ8uX9NkYDZBb/mw==}
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -3335,6 +3382,13 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hdr-histogram-js@3.0.1:
+    resolution: {integrity: sha512-l3GSdZL1Jr1C0kyb461tUjEdrRPZr8Qry7jByltf5JGrA0xvqOSrxRBfcrJqqV/AMEtqqhHhC6w8HW0gn76tRQ==}
+    engines: {node: '>=14'}
+
+  hdr-histogram-percentiles-obj@3.0.0:
+    resolution: {integrity: sha512-7kIufnBqdsBGcSZLPJwqHT3yhk1QTsSlFsVD3kx5ixH/AlgBs9yM1q6DPhXZ8f8gtdqgh7N7/5btRLpQsS2gHw==}
+
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
 
@@ -3362,6 +3416,9 @@ packages:
     resolution: {integrity: sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==}
     engines: {node: '>= 0.6'}
 
+  http-parser-js@0.5.10:
+    resolution: {integrity: sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==}
+
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
@@ -3373,6 +3430,9 @@ packages:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  hyperid@3.3.0:
+    resolution: {integrity: sha512-7qhCVT4MJIoEsNcbhglhdmBKb09QtcmJNiIQGq7js/Khf5FtQQ9bzcAuloeqBeee7XD7JqDeve9KNlQya5tSGQ==}
 
   icu-minify@4.13.0:
     resolution: {integrity: sha512-SIFMeUHZJjzS5RvIGvybKvWoHjDm9cGVEs2EpJ8PmywOdJLWyblPm7TdPLLoUtkJtwQD7iGhl2WMptZ+N0on+w==}
@@ -3942,6 +4002,15 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.chunk@4.2.0:
+    resolution: {integrity: sha512-ZzydJKfUHJwHa+hF5X66zLFCBrWn5GeF28OHEr4WVWtNDXlQ/IjWKPBiikqKo2ne0+v6JgCgJ0GzJp8k8bHC7w==}
+
+  lodash.clonedeep@4.5.0:
+    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
+
+  lodash.flatten@4.4.0:
+    resolution: {integrity: sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==}
+
   lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
 
@@ -3982,6 +4051,9 @@ packages:
 
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
+
+  manage-path@2.0.0:
+    resolution: {integrity: sha512-NJhyB+PJYTpxhxZJ3lecIGgh4kwIY2RAh44XvAz9UlqthlQwtPBf62uBVR8XaD8CRuSjQ6TnZH2lNJkbLPZM2A==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -4243,6 +4315,10 @@ packages:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
 
+  on-net-listen@1.1.2:
+    resolution: {integrity: sha512-y1HRYy8s/RlcBvDUwKXSmkODMdx4KSuIvloCnQYJ2LdBBC1asY4HtfhXwe3UWknLakATZDnbzht2Ijw3M1EqFg==}
+    engines: {node: '>=9.4.0 || ^8.9.4'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -4296,6 +4372,9 @@ packages:
 
   pako@0.2.9:
     resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
+
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -4367,6 +4446,16 @@ packages:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
 
+  playwright-core@1.62.0:
+    resolution: {integrity: sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.0:
+    resolution: {integrity: sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   pngjs@5.0.0:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
     engines: {node: '>=10.13.0'}
@@ -4396,6 +4485,10 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  pretty-bytes@5.6.0:
+    resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
+    engines: {node: '>=6'}
+
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -4405,6 +4498,10 @@ packages:
 
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
 
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
@@ -4511,6 +4608,9 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
+  reinterval@1.1.0:
+    resolution: {integrity: sha512-QIRet3SYrGp0HUHO88jVskiG6seqUGC5iAG7AwI/BV4ypGcuqk9Du6YQBUOUqm9c8pw1eyLoIaONifRua1lsEQ==}
+
   require-addon@1.2.0:
     resolution: {integrity: sha512-VNPDZlYgIYQwWp9jMTzljx+k0ZtatKlcvOhktZ/anNPI3dQ9NXk7cq2U4iJ1wd9IrytRnYhyEocFWbkdPb+MYA==}
     engines: {bare: '>=1.10.0'}
@@ -4549,6 +4649,9 @@ packages:
   resolve@2.0.0-next.5:
     resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
     hasBin: true
+
+  retimer@3.0.0:
+    resolution: {integrity: sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA==}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -4634,11 +4737,6 @@ packages:
 
   semver@7.7.2:
     resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  semver@7.7.3:
-    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -4882,6 +4980,9 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  subarg@1.0.0:
+    resolution: {integrity: sha512-RIrIdRY0X1xojthNcVtgT9sjpOGagEUKpZdgBUi054OEPFo282yg+zE+t1Rj3+RqKq2xStL7uUHhY+AjbC4BXg==}
+
   superstruct@2.0.2:
     resolution: {integrity: sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==}
     engines: {node: '>=14.0.0'}
@@ -4937,6 +5038,10 @@ packages:
   throttleit@2.1.0:
     resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
     engines: {node: '>=18'}
+
+  timestring@6.0.0:
+    resolution: {integrity: sha512-wMctrWD2HZZLuIlchlkE2dfXJh7J2KDI9Dwl+2abPYg0mswQHfOAyQW3jJg1pY5VfttSINZuKcXoB3FGypVklA==}
+    engines: {node: '>=8'}
 
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
@@ -5226,11 +5331,15 @@ packages:
   utrie@1.0.2:
     resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
 
+  uuid-parse@1.1.0:
+    resolution: {integrity: sha512-OdmXxA8rDsQ7YpNVbKSJkNzTw2I+S5WsbMDnCtIWSQaosNAcWtFuI/YK1TjzUI6nbkgiqEyh8gWngfcv8Asd9A==}
+
   uuid4@2.0.3:
     resolution: {integrity: sha512-CTpAkEVXMNJl2ojgtpLXHgz23dh8z81u6/HEPiQFOvBc/c2pde6TVHmH4uwY0d/GLF3tb7+VDAj4+2eJaQSdZQ==}
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-to-istanbul@9.3.0:
@@ -5615,6 +5724,8 @@ snapshots:
 
   '@albedo-link/intent@0.12.0': {}
 
+  '@assemblyscript/loader@0.19.23': {}
+
   '@babel/code-frame@7.28.6':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -5805,6 +5916,9 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@0.2.3': {}
+
+  '@colors/colors@1.5.0':
+    optional: true
 
   '@creit.tech/xbull-wallet-connect@0.4.0':
     dependencies:
@@ -6614,6 +6728,10 @@ snapshots:
   '@phosphor-icons/webcomponents@2.1.5':
     dependencies:
       lit: 3.3.0
+
+  '@playwright/test@1.62.0':
+    dependencies:
+      playwright: 1.62.0
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -8827,6 +8945,32 @@ snapshots:
 
   atomic-sleep@1.0.0: {}
 
+  autocannon@7.15.0:
+    dependencies:
+      chalk: 4.1.2
+      char-spinner: 1.0.1
+      cli-table3: 0.6.5
+      color-support: 1.1.3
+      cross-argv: 2.0.0
+      form-data: 4.0.5
+      has-async-hooks: 1.0.0
+      hdr-histogram-js: 3.0.1
+      hdr-histogram-percentiles-obj: 3.0.0
+      http-parser-js: 0.5.10
+      hyperid: 3.3.0
+      lodash.chunk: 4.2.0
+      lodash.clonedeep: 4.5.0
+      lodash.flatten: 4.4.0
+      manage-path: 2.0.0
+      on-net-listen: 1.1.2
+      pretty-bytes: 5.6.0
+      progress: 2.0.3
+      reinterval: 1.1.0
+      retimer: 3.0.0
+      semver: 7.8.5
+      subarg: 1.0.0
+      timestring: 6.0.0
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -9060,6 +9204,11 @@ snapshots:
 
   buffer-xor@1.0.3: {}
 
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
@@ -9118,6 +9267,8 @@ snapshots:
 
   char-regex@1.0.2: {}
 
+  char-spinner@1.0.1: {}
+
   charenc@0.0.2: {}
 
   chokidar@5.0.0:
@@ -9133,6 +9284,12 @@ snapshots:
       to-buffer: 1.2.2
 
   cjs-module-lexer@1.4.3: {}
+
+  cli-table3@0.6.5:
+    dependencies:
+      string-width: 4.2.3
+    optionalDependencies:
+      '@colors/colors': 1.5.0
 
   client-only@0.0.1: {}
 
@@ -9159,6 +9316,8 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  color-support@1.1.3: {}
 
   combined-stream@1.0.8:
     dependencies:
@@ -9214,6 +9373,8 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
+
+  cross-argv@2.0.0: {}
 
   cross-fetch@3.2.0:
     dependencies:
@@ -9881,6 +10042,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -9996,6 +10160,8 @@ snapshots:
     optionalDependencies:
       uglify-js: 3.19.3
 
+  has-async-hooks@1.0.0: {}
+
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -10030,6 +10196,14 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hdr-histogram-js@3.0.1:
+    dependencies:
+      '@assemblyscript/loader': 0.19.23
+      base64-js: 1.5.1
+      pako: 1.0.11
+
+  hdr-histogram-percentiles-obj@3.0.0: {}
+
   hermes-estree@0.25.1: {}
 
   hermes-parser@0.25.1:
@@ -10061,6 +10235,8 @@ snapshots:
       statuses: 1.5.0
       toidentifier: 1.0.0
 
+  http-parser-js@0.5.10: {}
+
   human-signals@2.1.0: {}
 
   humanize-ms@1.2.1:
@@ -10068,6 +10244,12 @@ snapshots:
       ms: 2.1.3
 
   husky@9.1.7: {}
+
+  hyperid@3.3.0:
+    dependencies:
+      buffer: 5.7.1
+      uuid: 8.3.2
+      uuid-parse: 1.1.0
 
   icu-minify@4.13.0:
     dependencies:
@@ -10816,6 +10998,12 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.chunk@4.2.0: {}
+
+  lodash.clonedeep@4.5.0: {}
+
+  lodash.flatten@4.4.0: {}
+
   lodash.memoize@4.1.2: {}
 
   lodash.merge@4.6.2: {}
@@ -10851,6 +11039,8 @@ snapshots:
   makeerror@1.0.12:
     dependencies:
       tmpl: 1.0.5
+
+  manage-path@2.0.0: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -10962,14 +11152,14 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.13.0: {}
 
-  next-intl@4.13.0(next@16.1.4(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@5.9.3):
+  next-intl@4.13.0(next@16.1.4(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.62.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@5.9.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.10
       '@parcel/watcher': 2.5.6
       '@swc/core': 1.15.43
       icu-minify: 4.13.0
       negotiator: 1.0.0
-      next: 16.1.4(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.1.4(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.62.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-intl-swc-plugin-extractor: 4.13.0
       po-parser: 2.1.1
       react: 19.2.7
@@ -10979,7 +11169,7 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  next@16.1.4(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.1.4(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.62.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 16.1.4
       '@swc/helpers': 0.5.15
@@ -10999,6 +11189,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 16.1.4
       '@next/swc-win32-x64-msvc': 16.1.4
       '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.62.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -11090,6 +11281,8 @@ snapshots:
 
   on-exit-leak-free@2.1.2: {}
 
+  on-net-listen@1.1.2: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -11178,6 +11371,8 @@ snapshots:
 
   pako@0.2.9: {}
 
+  pako@1.0.11: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -11255,6 +11450,14 @@ snapshots:
     dependencies:
       find-up: 4.1.0
 
+  playwright-core@1.62.0: {}
+
+  playwright@1.62.0:
+    dependencies:
+      playwright-core: 1.62.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
   pngjs@5.0.0: {}
 
   po-parser@2.1.1: {}
@@ -11279,6 +11482,8 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  pretty-bytes@5.6.0: {}
+
   pretty-format@29.7.0:
     dependencies:
       '@jest/schemas': 29.6.3
@@ -11288,6 +11493,8 @@ snapshots:
   process-nextick-args@2.0.1: {}
 
   process-warning@5.0.0: {}
+
+  progress@2.0.3: {}
 
   prompts@2.4.2:
     dependencies:
@@ -11423,6 +11630,8 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
+  reinterval@1.1.0: {}
+
   require-addon@1.2.0:
     dependencies:
       bare-addon-resolve: 1.9.6
@@ -11457,6 +11666,8 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  retimer@3.0.0: {}
 
   reusify@1.1.0: {}
 
@@ -11591,8 +11802,6 @@ snapshots:
   semver@7.7.1: {}
 
   semver@7.7.2: {}
-
-  semver@7.7.3: {}
 
   semver@7.8.5: {}
 
@@ -11900,6 +12109,10 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.28.6
 
+  subarg@1.0.0:
+    dependencies:
+      minimist: 1.2.8
+
   superstruct@2.0.2: {}
 
   supports-color@7.2.0:
@@ -11963,6 +12176,8 @@ snapshots:
       real-require: 0.2.0
 
   throttleit@2.1.0: {}
+
+  timestring@6.0.0: {}
 
   tiny-inflate@1.0.3: {}
 
@@ -12223,6 +12438,8 @@ snapshots:
   utrie@1.0.2:
     dependencies:
       base64-arraybuffer: 1.0.2
+
+  uuid-parse@1.1.0: {}
 
   uuid4@2.0.3: {}
 


### PR DESCRIPTION
…vibe-check screen

Adds an NFT Activity card to Screen4VibeCheck populated from achievementCalculator:
- Detects NFT mints from Soroban invoke_host_function calls (mint/create_nft/nft_mint keywords) and non-LP trustline operations (change_trust/allow_trust/set_trust_line_flags), incrementing nftMintCount and per-creator counts.
- Adds NftActivitySummary { mintCount, topCreatorAddress, topCreatorMintCount } to IndexerResult → WrapResult (via wrapResultMapper) → Page prop → UI.
- NftActivityCard in Screen4VibeCheck.tsx renders: · animated mint count with Sparkles glow icon · top creator row with Crown icon + shortenAddress() + mono font · returns null when mintCount === 0 (section hidden rather than showing 0)
- Fixes achievementCalculator bugs exposed by the unit suite: · assignPersona() (6-archetype) replaces legacy detectPersona() (4-archetype) · successfulTxCount excludes failed txs but counts empty-ops successful ones · processOfferOperation now accepts assetVolumeMap param (was undefined) · path payment volume no longer double-counts when only flat amount present · mostActiveAsset ranks by volume first, with operation-count tiebreaker
- Resolves JSX in Screen4VibeCheck: added missing </div> for the space-y-6 cards container; made NftActivityCard summary prop optional to match the store.

44/44 achievementCalculator.unit.test.ts passing.
Closes #92