### PR TITLE
feat(persona): add fallback when AI persona action is unavailable

### DIFF
--- a/app/[locale]/persona/page.tsx
+++ b/app/[locale]/persona/page.tsx
@@ -7,6 +7,7 @@ import { Home, Share2, ChevronRight, X } from "lucide-react";
 import Link from "next/link";
 import { readStreamableValue } from "ai/rsc";
 import { getArchetypeDescription } from "@/data/archetypeConfig";
+import { generatePersonaDescription } from "@/app/actions/generate-persona";
 
 // Removed theme system - using standard CSS variables from globals.css
 const useConfetti = (color?: string) => {

--- a/app/actions/__tests__/generate-persona.test.ts
+++ b/app/actions/__tests__/generate-persona.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Tests for generate-persona server action.
+ *
+ * Covers:
+ *  - Action rejection when OPENAI_API_KEY is missing
+ *  - Empty stream from the AI SDK
+ *  - API-level errors (auth, quota, network)
+ *  - Deterministic fallback behaviour
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+
+// ─── Mock ai/rsc module ───────────────────────────────────────────────────────
+
+vi.mock("ai/rsc", () => {
+  function createStreamable() {
+    const chunks: string[] = [];
+    let doneResolve: () => void;
+    const donePromise = new Promise<void>((resolve) => {
+      doneResolve = resolve;
+    });
+    const sv = {
+      _chunks: chunks,
+      _donePromise: donePromise,
+      append: (chunk: string) => {
+        chunks.push(chunk);
+      },
+      done: () => {
+        doneResolve();
+      },
+      error: () => {
+        doneResolve();
+      },
+    };
+    return Object.assign(sv, { value: sv });
+  }
+
+  return {
+    createStreamableValue: vi.fn(() => createStreamable()),
+    readStreamableValue: vi.fn(async function* (value: any) {
+      if (typeof value !== "object" || value === null) return;
+      const p = value._donePromise || value.donePromise;
+      const c = value._chunks || value.chunks;
+      if (!p || !c) return;
+      await p;
+      for (const chunk of c) {
+        yield chunk;
+      }
+    }),
+  };
+});
+
+// ─── Mock ai module ───────────────────────────────────────────────────────────
+
+vi.mock("ai", () => ({
+  streamText: vi.fn(),
+}));
+
+// ─── Mock @ai-sdk/openai module ──────────────────────────────────────────────
+
+vi.mock("@ai-sdk/openai", () => ({
+  openai: vi.fn((model: string) => ({ model })),
+}));
+
+// ─── Module under test ─────────────────────────────────────────────────────────
+
+import { generatePersonaDescription } from "../generate-persona";
+import type { PersonaMetrics } from "../generate-persona";
+
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+
+async function consumeStream(
+  streamVal: Awaited<ReturnType<typeof generatePersonaDescription>>,
+): Promise<string> {
+  const { readStreamableValue } = await import("ai/rsc");
+  let result = "";
+  for await (const chunk of readStreamableValue(streamVal)) {
+    if (chunk) {
+      result += chunk;
+    }
+  }
+  return result;
+}
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────────
+
+const baseMetrics: PersonaMetrics = {
+  username: "testuser",
+  topDapp: "Lobstr",
+  transactionCount: 42,
+  favoriteChain: "Stellar",
+  percentile: 75,
+  totalDapps: 3,
+  vibes: [{ type: "DeFi", percentage: 60 }],
+};
+
+// ─── Tests: Missing / placeholder API key ──────────────────────────────────────
+
+describe("generatePersonaDescription — missing or placeholder API key", () => {
+  const OLD_KEY = process.env.OPENAI_API_KEY;
+
+  afterAll(() => {
+    process.env.OPENAI_API_KEY = OLD_KEY;
+  });
+
+  it("returns a deterministic fallback when OPENAI_API_KEY is not set", async () => {
+    delete process.env.OPENAI_API_KEY;
+
+    const response = await generatePersonaDescription(baseMetrics);
+    const text = await consumeStream(response);
+
+    expect(text).toBeTruthy();
+    expect(typeof text).toBe("string");
+    expect(text.length).toBeGreaterThan(10);
+  });
+
+  it("returns a deterministic fallback when OPENAI_API_KEY is a placeholder", async () => {
+    process.env.OPENAI_API_KEY = "sk-your-key-here";
+
+    const response = await generatePersonaDescription(baseMetrics);
+    const text = await consumeStream(response);
+
+    expect(text).toBeTruthy();
+    expect(typeof text).toBe("string");
+    expect(text.length).toBeGreaterThan(10);
+  });
+
+  it("returns the same fallback for identical metrics (deterministic)", async () => {
+    delete process.env.OPENAI_API_KEY;
+
+    const resp1 = await generatePersonaDescription(baseMetrics);
+    const resp2 = await generatePersonaDescription(baseMetrics);
+
+    const text1 = await consumeStream(resp1);
+    const text2 = await consumeStream(resp2);
+
+    expect(text1).toBe(text2);
+  });
+
+  it("does NOT call the real streamText when API key is missing", async () => {
+    delete process.env.OPENAI_API_KEY;
+
+    const { streamText } = await import("ai");
+
+    await generatePersonaDescription(baseMetrics);
+
+    expect(streamText).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Tests: Stream handling ────────────────────────────────────────────────────
+
+describe("generatePersonaDescription — stream handling", () => {
+  const OLD_KEY = process.env.OPENAI_API_KEY;
+
+  beforeAll(() => {
+    process.env.OPENAI_API_KEY = "sk-real-key-12345";
+  });
+
+  afterAll(() => {
+    process.env.OPENAI_API_KEY = OLD_KEY;
+  });
+
+  it("returns a fallback when the AI stream yields no chunks", async () => {
+    async function* emptyStream() {
+      // yield nothing
+    }
+
+    const { streamText } = await import("ai");
+    (streamText as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      textStream: emptyStream(),
+    });
+
+    const response = await generatePersonaDescription(baseMetrics);
+    const text = await consumeStream(response);
+
+    expect(text).toBeTruthy();
+    expect(typeof text).toBe("string");
+    expect(text.length).toBeGreaterThan(10);
+  });
+});
+
+// ─── Tests: Error recovery ────────────────────────────────────────────────────
+
+describe("generatePersonaDescription — error recovery", () => {
+  const OLD_KEY = process.env.OPENAI_API_KEY;
+
+  beforeAll(() => {
+    process.env.OPENAI_API_KEY = "sk-real-key-12345";
+  });
+
+  afterAll(() => {
+    process.env.OPENAI_API_KEY = OLD_KEY;
+  });
+
+  it("returns a fallback on quota / auth errors instead of throwing", async () => {
+    const { streamText } = await import("ai");
+    (streamText as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("Insufficient quota"),
+    );
+
+    const response = await generatePersonaDescription(baseMetrics);
+    const text = await consumeStream(response);
+
+    expect(text).toBeTruthy();
+    expect(text.length).toBeGreaterThan(10);
+  });
+
+  it("returns a fallback on network errors", async () => {
+    const { streamText } = await import("ai");
+    (streamText as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("fetch failed"),
+    );
+
+    const response = await generatePersonaDescription(baseMetrics);
+    const text = await consumeStream(response);
+
+    expect(text).toBeTruthy();
+    expect(text.length).toBeGreaterThan(10);
+  });
+
+  it("returns a fallback on 401 authentication errors", async () => {
+    const { streamText } = await import("ai");
+    (streamText as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("401 - Authentication failed"),
+    );
+
+    const response = await generatePersonaDescription(baseMetrics);
+    const text = await consumeStream(response);
+
+    expect(text).toBeTruthy();
+    expect(text.length).toBeGreaterThan(10);
+  });
+});

--- a/app/actions/generate-persona.ts
+++ b/app/actions/generate-persona.ts
@@ -17,6 +17,56 @@ export interface PersonaMetrics {
   totalDapps?: number;
 }
 
+const FALLBACK_DESCRIPTIONS: string[] = [
+  "A Stellar pioneer navigating the galaxy of DeFi with quiet confidence.",
+  "On-chain adventurer collecting experiences across the Stellar ecosystem.",
+  "Stellar-native explorer charting a unique course through decentralized finance.",
+  "Blockchain journeyer with a footprint across the Stellar network.",
+  "Decentralized dreamer making moves on the Stellar blockchain.",
+];
+
+function pickFallbackDescription(metrics: PersonaMetrics): string {
+  const seed =
+    ((metrics.transactionCount ?? 0) +
+      (metrics.totalDapps ?? 0) +
+      (metrics.percentile ?? 50)) %
+    FALLBACK_DESCRIPTIONS.length;
+  return FALLBACK_DESCRIPTIONS[seed];
+}
+
+function isAiConfigured(): boolean {
+  return !!(
+    process.env.OPENAI_API_KEY &&
+    process.env.OPENAI_API_KEY !== "sk-your-key-here"
+  );
+}
+
+function logSafeDiagnostics(): void {
+  const hasKey = !!process.env.OPENAI_API_KEY;
+  const isDefaultPlaceholder =
+    process.env.OPENAI_API_KEY === "sk-your-key-here";
+
+  if (!hasKey) {
+    console.warn(
+      "[generate-persona] OPENAI_API_KEY is not set. AI persona generation will not be available. " +
+        "Set OPENAI_API_KEY in your environment to enable AI-powered persona descriptions.",
+    );
+  } else if (isDefaultPlaceholder) {
+    console.warn(
+      "[generate-persona] OPENAI_API_KEY is set to the default placeholder value. " +
+        "Update OPENAI_API_KEY to a valid key to enable AI-powered persona descriptions.",
+    );
+  } else {
+    console.log(
+      "[generate-persona] OPENAI_API_KEY is configured (masked: " +
+        process.env.OPENAI_API_KEY.slice(0, 8) +
+        "..." +
+        process.env.OPENAI_API_KEY.slice(-4) +
+        ")",
+    );
+  }
+}
+
 export async function generatePersonaDescription(metrics: PersonaMetrics) {
   "use server";
 
@@ -24,6 +74,15 @@ export async function generatePersonaDescription(metrics: PersonaMetrics) {
 
   (async () => {
     try {
+      // Check if AI is configured — if not, fall back immediately
+      if (!isAiConfigured()) {
+        logSafeDiagnostics();
+        const fallback = pickFallbackDescription(metrics);
+        streamable.append(fallback);
+        streamable.done();
+        return;
+      }
+
       const metricsText = `
 <user_metrics>
 <username>${(metrics.username || "Unknown").replace(/<[^>]*>/g, "")}</username>
@@ -61,16 +120,45 @@ Generate a single witty persona description. Do NOT use any formatting like aste
         maxTokens: 200,
       });
 
+      let chunkCount = 0;
       for await (const chunk of result.textStream) {
-        streamable.append(chunk);
+        if (chunk) {
+          streamable.append(chunk);
+          chunkCount++;
+        }
+      }
+
+      // Handle empty stream — no chunks were received from the AI
+      if (chunkCount === 0) {
+        console.warn(
+          "[generate-persona] AI stream returned empty — no chunks received. Falling back to deterministic description.",
+        );
+        const fallback = pickFallbackDescription(metrics);
+        streamable.append(fallback);
       }
 
       streamable.done();
     } catch (error) {
-      console.error("Error generating persona:", error);
-      streamable.error(
-        error instanceof Error ? error.message : "Unknown error",
-      );
+      console.error("[generate-persona] Error generating persona:", error);
+      // Safe diagnostic: log whether the error is configuration-related
+      if (error instanceof Error) {
+        const message = error.message.toLowerCase();
+        if (
+          message.includes("api key") ||
+          message.includes("unauthorized") ||
+          message.includes("403") ||
+          message.includes("401") ||
+          message.includes("insufficient_quota")
+        ) {
+          console.warn(
+            "[generate-persona] AI configuration or quota error detected. Falling back to deterministic description.",
+          );
+        }
+      }
+      // Fall back to a deterministic description instead of propagating an error
+      const fallback = pickFallbackDescription(metrics);
+      streamable.append(fallback);
+      streamable.done();
     }
   })();
 


### PR DESCRIPTION
## Overview

This PR adds graceful fallback handling when the AI persona description action is unavailable due to missing API configuration or streaming failures. Instead of blocking the reveal or propagating errors, the UI now shows a deterministic fallback description based on the user's on-chain metrics.

## Related Issue

Closes #268

## Changes

### 🛡️ Fallback Logic & Diagnostics

* **[ADD]** `app/actions/generate-persona.ts`
  - `isAiConfigured()` — checks if `OPENAI_API_KEY` is set and not a placeholder; returns fallback immediately if missing
  - `logSafeDiagnostics()` — logs safe config diagnostics without leaking the API key (shows only masked prefix/suffix)
  - `pickFallbackDescription()` — deterministically selects from 5 crypto-themed fallback descriptions based on user metrics (transaction count, dapps, percentile)
  - Empty stream detection — falls back to deterministic description when AI returns zero chunks
  - Error recovery — catches auth/quota/network errors and falls back gracefully instead of propagating them

* **[FIX]** `app/[locale]/persona/page.tsx`
  - Added missing import for `generatePersonaDescription` server action

* **[ADD]** `app/actions/__tests__/generate-persona.test.ts`
  - Coverage for: missing API key, placeholder API key, deterministic fallback consistency, empty AI stream, quota/auth/network errors

## Verification Results

```
pnpm vitest run app/actions/__tests__/generate-persona.test.ts
✅ 8/8 passed
```

| Acceptance Criteria | Status |
| --- | --- |
| Show deterministic fallback description without blocking reveal | ✅ Fallback description is returned immediately when AI is unavailable |
| Log safe diagnostics for missing configuration | ✅ `console.warn` with safe messages — no key leakage |
| Add tests for action rejection and empty stream | ✅ 8 tests covering missing key, placeholder, empty stream, and API errors |